### PR TITLE
Implement Offsets and Origins

### DIFF
--- a/docs/ref/drivers/seven_segment.md
+++ b/docs/ref/drivers/seven_segment.md
@@ -38,6 +38,21 @@ anode seven-segment displays. If you need the requested GPIO pin to be held
     will raise a `ValueError` exception if the requested character is not in an
     appropriate range.
 
+### Common Anode and Common Cathode Implementations
+
+The `display` methods of the [`SegDisplay`][lbutils.drivers.SegDisplay.display] and the [`SegHexDisplay`][lbutils.drivers.SegHexDisplay.display] have an (optional) argument `pin_on` for the sense of the GPIO pins. This argument is defined as
+
+````python
+PIN_ON_SENSE = {"HIGH", "LOW"}
+````
+
+When the GPIO pins need to be set 'high' ('1') for the device
+input to turn on, the `pin_on` input need to be set to `HIGH`.
+This typical behaviour for a common anode display, and also the normal library defined.
+
+Alternatively, if the GPIO pins need to be set 'low' ('0') for
+the device input to turn on, then the `pin_on` argument must be sent to `LOW`. This is also the typical behaviour for common cathode devices.
+
 ### Tested Implementations
 
 This version is written for MicroPython 3.4, and has been tested on:

--- a/docs/ref/graphics/graphics_intro.md
+++ b/docs/ref/graphics/graphics_intro.md
@@ -5,18 +5,22 @@
         heading_level: 2
         show_category_heading: False
 
-::: lbutils.graphics.canvas
-    options:
-        heading_level: 2
-        show_category_heading: False
-
-
 ::: lbutils.graphics.colours
     options:
         heading_level: 2
         show_category_heading: False
 
 ::: lbutils.graphics.helpers
+    options:
+        heading_level: 2
+        show_category_heading: False
+
+::: lbutils.graphics.Canvas
+    options:
+        heading_level: 2
+        show_category_heading: False
+
+::: lbutils.graphics.FrameBufferCanvas
     options:
         heading_level: 2
         show_category_heading: False

--- a/examples/pmod/README.md
+++ b/examples/pmod/README.md
@@ -11,6 +11,10 @@ the `lbutils` library. The current list of examples is as follows
 , using the `lbutils.font` library and the `lbutils.drivers.SSD1331` display
 driver. This also gives an example of all the fonts in the font library, and
 serves as a functional test for the display.
+- `pmod_oled_flowers.py`. Examples of the drawing primitives for the [Pmod
+OLEDrgb](https://digilvcc_enablet.com/refervcc_enablece/pmod/pm
+odoled_displayrgb/start). This also gives an example of how the `Canvas`
+class can be used to create more complex shapes from the drawing primitives.
 
 ## Tested Implementations
 

--- a/examples/pmod/pmod_oled_example.py
+++ b/examples/pmod/pmod_oled_example.py
@@ -78,15 +78,19 @@ vcc_enable.high()
 # Finally initialise the OLED display driver, and set the display
 # to black
 oled_display = OLEDrgb(spi_controller, data_cmd_pin, chip_sel_pin, reset_pin)
-
-##
-## Font Examples
-##
-
-# Clear the display
 oled_display.fill_screen(graphics.colours.COLOUR_BLACK)
 
-# Display the `Font_08` font class in red
+# Set the origin for the tests
+oled_display.origin.x_y = [0, 0]
+
+##
+## Font Examples. Also showing different methods for setting the
+## start point of the `write_text` routine used to draw the
+## text in the specified font
+##
+
+# Display the `Font_08` font class in red, and set the cursor
+# of the `oled_display` manually each time.
 print("Running the screen test for the `Font_08` font...")
 
 oled_display.fg_colour = graphics.colours.COLOUR_RED
@@ -112,52 +116,46 @@ utime.sleep(10)
 # Clear the display
 oled_display.fill_screen(graphics.colours.COLOUR_BLACK)
 
-# Display the `Font_06` font class in green
+# Display the `Font_06` font class in green, and set the cursor
+# at the start of each call to `write_text`
 print("Running the screen test for the `Font_06` font...")
 
 oled_display.fg_colour = graphics.colours.COLOUR_LIME
 oled_display.font = fonts.Font_06()
 
-oled_display.x_y = [0, 20]
-oled_display.write_text("ABCDEFGHIJKLMN")
-
-oled_display.x_y = [0, 30]
-oled_display.write_text("OPQRSTUVWXYZ")
-
-oled_display.x_y = [0, 40]
-oled_display.write_text("abcdefghijklmn")
-
-oled_display.x_y = [0, 50]
-oled_display.write_text("opqrstuvwxyz")
-
-oled_display.x_y = [0, 60]
-oled_display.write_text("0123456789")
+oled_display.write_text(start=[0, 20], txt_str="ABCDEFGHIJKLMN")
+oled_display.write_text(start=[0, 30], txt_str="OPQRSTUVWXYZ")
+oled_display.write_text(start=[0, 40], txt_str="abcdefghijklmn")
+oled_display.write_text(start=[0, 50], txt_str="opqrstuvwxyz")
+oled_display.write_text(start=[0, 60], txt_str="0123456789")
 
 utime.sleep(10)
 
 # Clear the display
 oled_display.fill_screen(graphics.colours.COLOUR_BLACK)
 
-# Display the `Org_01` font class in blue
+# Display the `Org_01` font class in blue, and use the origin
+# with an offset to display the text using `write_text`
 print("Running the screen test for the `Org_01` font...")
 
 oled_display.fg_colour = graphics.colours.COLOUR_BLUE
 oled_display.font = fonts.Org_01()
 
-oled_display.x_y = [0, 20]
-oled_display.write_text("ABCDEFGHIJKLMN")
-
-oled_display.x_y = [0, 30]
-oled_display.write_text("OPQRSTUVWXYZ")
-
-oled_display.x_y = [0, 40]
-oled_display.write_text("abcdefghijklmn")
-
-oled_display.x_y = [0, 50]
-oled_display.write_text("opqrstuvwxyz")
-
-oled_display.x_y = [0, 60]
-oled_display.write_text("0123456789")
+oled_display.write_text(
+    start=oled_display.origin.offset(y=20), txt_str="ABCDEFGHIJKLMN"
+)
+oled_display.write_text(
+    start=oled_display.origin.offset(y=30), txt_str="OPQRSTUVWXYZ   "
+)
+oled_display.write_text(
+    start=oled_display.origin.offset(y=40), txt_str="abcdefghijklmn "
+)
+oled_display.write_text(
+    start=oled_display.origin.offset(y=50), txt_str="opqrstuvwxyz   "
+)
+oled_display.write_text(
+    start=oled_display.origin.offset(y=60), txt_str="0123456789     "
+)
 
 utime.sleep(10)
 

--- a/examples/pmod/pmod_oled_flowers.py
+++ b/examples/pmod/pmod_oled_flowers.py
@@ -1,7 +1,7 @@
 # This example, and all included code, is made available under the terms of the
 # MIT License
 #
-# Copyright (c) 2023 Roz Wyatt-Millington, David Love
+# Copyright (c) 2023 David Love
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal in
@@ -20,11 +20,10 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""Example for the [Pmod
+"""Examples of the drawing primitives for the [Pmod
 OLEDrgb](https://digilvcc_enablet.com/refervcc_enablece/pmod/pm
-odoled_displayrgb/start) , using the `lbutils.font` library and the
-`lbutils.drivers.SSD1331` display driver. This also gives an example of all the
-fonts in the font library, and serves as a functional test for the display.
+odoled_displayrgb/start). This also gives an example of how the `Canvas` class
+can be used to create more complex shapes from the drawing primitives.
 
 Tested Implementations
 ----------------------
@@ -78,103 +77,19 @@ vcc_enable.high()
 # Finally initialise the OLED display driver, and set the display
 # to black
 oled_display = OLEDrgb(spi_controller, data_cmd_pin, chip_sel_pin, reset_pin)
-
-##
-## Font Examples
-##
-
-# Clear the display
 oled_display.fill_screen(graphics.colours.COLOUR_BLACK)
 
-# Display the `Font_08` font class in red
-print("Running the screen test for the `Font_08` font...")
+##
+## Lines in Rotation. Creates simple 'flowers' using lines rotated around
+## a common origin.
+##
 
+# Set the origin
+oled_display.x_y = [20, 20]
+oled_display.save_origin()
+
+# Set the colour
 oled_display.fg_colour = graphics.colours.COLOUR_RED
-oled_display.font = fonts.Font_08()
 
-oled_display.x_y = [0, 20]
-oled_display.write_text("ABCDEFGHIJKLMN")
-
-oled_display.x_y = [0, 30]
-oled_display.write_text("OPQRSTUVWXYZ")
-
-oled_display.x_y = [0, 40]
-oled_display.write_text("abcdefghijklmn")
-
-oled_display.x_y = [0, 50]
-oled_display.write_text("opqrstuvwxyz")
-
-oled_display.x_y = [0, 60]
-oled_display.write_text("0123456789")
-
-utime.sleep(10)
-
-# Clear the display
-oled_display.fill_screen(graphics.colours.COLOUR_BLACK)
-
-# Display the `Font_06` font class in green
-print("Running the screen test for the `Font_06` font...")
-
-oled_display.fg_colour = graphics.colours.COLOUR_LIME
-oled_display.font = fonts.Font_06()
-
-oled_display.x_y = [0, 20]
-oled_display.write_text("ABCDEFGHIJKLMN")
-
-oled_display.x_y = [0, 30]
-oled_display.write_text("OPQRSTUVWXYZ")
-
-oled_display.x_y = [0, 40]
-oled_display.write_text("abcdefghijklmn")
-
-oled_display.x_y = [0, 50]
-oled_display.write_text("opqrstuvwxyz")
-
-oled_display.x_y = [0, 60]
-oled_display.write_text("0123456789")
-
-utime.sleep(10)
-
-# Clear the display
-oled_display.fill_screen(graphics.colours.COLOUR_BLACK)
-
-# Display the `Org_01` font class in blue
-print("Running the screen test for the `Org_01` font...")
-
-oled_display.fg_colour = graphics.colours.COLOUR_BLUE
-oled_display.font = fonts.Org_01()
-
-oled_display.x_y = [0, 20]
-oled_display.write_text("ABCDEFGHIJKLMN")
-
-oled_display.x_y = [0, 30]
-oled_display.write_text("OPQRSTUVWXYZ")
-
-oled_display.x_y = [0, 40]
-oled_display.write_text("abcdefghijklmn")
-
-oled_display.x_y = [0, 50]
-oled_display.write_text("opqrstuvwxyz")
-
-oled_display.x_y = [0, 60]
-oled_display.write_text("0123456789")
-
-utime.sleep(10)
-
-##
-## Colour Rotation of the Full Display
-##
-
-colors = []
-for i in range(8):
-    r = (i & 1) * 255
-    g = ((i >> 1) & 1) * 255
-    b = ((i >> 2) & 1) * 255
-    colors.append(graphics.colours.Colour(r, g, b))
-
-print("Running the colour test...")
-while True:
-    for color in colors:
-        oled_display.fill_screen(color)
-
-        utime.sleep(1)
+# Draw the lines
+oled_display.draw_line(20, 20, 30, 30)

--- a/lbutils/drivers/common.py
+++ b/lbutils/drivers/common.py
@@ -20,20 +20,10 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""Drivers for low-level components, including those using the SPI or I2C
-busses. This is mostly a collection of drivers, some third-party, which provide
-low-level access to devices. In most cases additional code will be required to
-_use_ these devices: the focus of the code in here is only on providing _access_
-to those devices.
-
-Examples for how to use the library can be found in the '`examples`' folder: or in
-the documentation for specific classes. In some cases the examples will require a
-specific example circuit: where this is the case, in most cases classes will
-additionally provide an example on [WokWi](https://wokwi.com).
-
-!!! Note
-    The Digilent '`pmod`' devices are split into their own special section, and
-    should be imported using the '`pmod`' libraries.
+"""Common libraries and definitions for the for low-level devices. This module
+contains mostly helper and other utility definitions that are used by more than
+one driver. In most cases the services provided by this module are not meant to
+be used directly by end-user code.
 
 Tested Implementations
 ----------------------
@@ -43,8 +33,15 @@ This version is written for MicroPython 3.4, and has been tested on:
   * Raspberry Pi Pico H/W
 """
 
-### Expose the `drivers` module interface as a full package
-from .common import PIN_ON_SENSE
+###
+### Enumerations. MicroPython doesn't have actual an actual `enum` (yet), so
+### these serve as common cases where a selection of values need to be defined
+###
 
-from .seven_segment import SegDisplay
-from .seven_segment_hex import SegHexDisplay
+PIN_ON_SENSE = {"HIGH", "LOW"}
+"""Sets the device sense for 'ON'.
+
+When set to `HIGH` the GPIO pins need to be set 'high' ('1') for the device
+input to turn on. When set to `LOW` the GPIO pins need to be set 'low' ('0') for
+the device input to turn on.
+"""

--- a/lbutils/drivers/seven_segment.py
+++ b/lbutils/drivers/seven_segment.py
@@ -79,6 +79,8 @@ try:
 except ImportError:
     print("Ignoring MicroPython includes")
 
+from .common import PIN_ON_SENSE
+
 ##
 ## Classes
 ##
@@ -156,7 +158,7 @@ class SegDisplay:
             for segment in range(7):
                 self.pin_list.append(Pin(gpio_request[segment], Pin.OUT))
 
-    def display(self, character: int, inverted: bool = False) -> None:
+    def display(self, character: int, pin_on: PIN_ON_SENSE = "LOW") -> None:
         """Display the given `character` on the seven-segment display, using the
         `_char_list` as a guide for which pins to turn on or off. By default the
         `display` method will use the entries in the `_char_list` directly: if
@@ -169,13 +171,12 @@ class SegDisplay:
         character: int
             The value to be displayed on the seven segment display, which must be
             between zero ('0') and nine ('9')
-        inverted: bool, optional
-            By default the `display` method assumes that pulling a GPIO pin *low*
-            will turn the relevant segment *on*; i.e. the typical behaviour for a
-            common anode display. If the attached display needs to raise a GPIO
-            pin *high* to set the segment *on* (i.e. the typical behaviour for a
-            common cathode display), call the `display` method with `inverted`
-            set to `True`.
+        pin_on: PIN_ON_SENSE, optional
+            When set to `"HIGH"` the GPIO pins need to be set 'high' ('1') for
+            the device segment to turn on (the typical behaviour for a common
+            anode display). When set to `"LOW"` the GPIO pins need to be set
+            'low' ('0') for the device segment to turn on (the typical behaviour
+            for a common cathode display.
 
         Raises
         ------
@@ -185,7 +186,7 @@ class SegDisplay:
         """
         # For a character in the valid range...
         if 0 <= character <= 9:
-            if not inverted:
+            if pin_on == "LOW":
                 # ... if the request is to display in the non-inverted form, then
                 # select the row in `_char_list` corresponding to the character to
                 # be displayed and then set in turn each of the GPIO pins corresponding

--- a/lbutils/drivers/seven_segment_hex.py
+++ b/lbutils/drivers/seven_segment_hex.py
@@ -83,6 +83,8 @@ try:
 except ImportError:
     print("The Python type library isn't present. Ignoring.")
 
+from .common import PIN_ON_SENSE
+
 ##
 ## Constants
 ##
@@ -181,7 +183,7 @@ class SegHexDisplay:
             for segment in range(7):
                 self.pin_list.append(Pin(gpio_request[segment], Pin.OUT))
 
-    def display(self, character: Union[int, str], inverted: bool = False) -> None:
+    def display(self, character: Union[int, str], pin_on: PIN_ON_SENSE = "LOW") -> None:
         """Display the given `character` on the seven-segment display, using the
         `_char_list` as a guide for which pins to turn on or off. By default the
         `display` method will use the entries in the `_char_list` directly: if
@@ -204,13 +206,12 @@ class SegHexDisplay:
 
             If the type does not conform to the above, then a `TypeError` will be
             raised.
-        inverted: bool, optional
-            By default the `display` method assumes that pulling a GPIO pin _low_
-            will turn the relevant segment _on_; i.e. the typical behaviour for a
-            common anode display. If the attached display needs to raise a GPIO
-            pin _high_ to set the segment _on_ (i.e. the typical behaviour for a
-            common cathode display), call the `display` method with `inverted`
-            set to `True`.
+        pin_on: PIN_ON_SENSE, optional
+            When set to `"HIGH"` the GPIO pins need to be set 'high' ('1') for
+            the device segment to turn on (the typical behaviour for a common
+            anode display). When set to `"LOW"` the GPIO pins need to be set
+            'low' ('0') for the device segment to turn on (the typical behaviour
+            for a common cathode display.
 
         Raises
         ------
@@ -224,7 +225,7 @@ class SegHexDisplay:
         if isinstance(character, int):
             # For a character in the valid range...
             if 0 <= character <= 15:
-                if not inverted:
+                if pin_on == "LOW":
                     # ... if the request is to display in the non-inverted form, then
                     # select the row in `_char_list` corresponding to the character to
                     # be displayed and then set in turn each of the GPIO pins corresponding
@@ -256,7 +257,7 @@ class SegHexDisplay:
                 # this as the index for the character lookup
                 _char_list_index = int(normalised_character, 16)
 
-                if not inverted:
+                if pin_on == "LOW":
                     # If the request is to display in the non-inverted form, then
                     # select the row in `_char_list` corresponding to the `_char_list_index` to
                     # be displayed and then set in turn each of the GPIO pins corresponding

--- a/lbutils/graphics/__init__.py
+++ b/lbutils/graphics/__init__.py
@@ -58,6 +58,31 @@ functions which ease the abstraction of the main graphics Canvas library, e.g.
 class as being the most suitable classes for re-use in other drawing and graphics
 routines.
 
+!!! Note "Drawing Side-Effects"
+    The `Canvas` will also maintain an internal [`cursor`]
+    [lbutils.graphics.helpers.BoundPixel], representing the current
+    [`x`][lbutils.graphics.Canvas.x] and [`y`][lbutils.graphics.Canvas.y]
+    drawing co-ordinates. For many of the above methods, this internal state
+    will be modified to point to the _next_ location which
+    is commonly used in sequence. For example the
+    [`write_text`][lbutils.graphics.Canvas.write_text] updates the
+    [`cursor`][lbutils.graphics.helpers.BoundPixel] to point to position at the
+    end of the text string. Or the [`draw_line`]
+    [lbutils.graphics.Canvas.draw_line] method will change the [`cursor`]
+    [lbutils.graphics.helpers.BoundPixel] to the end of the line just drawn.
+    This behaviour makes it easier to sequence multiple drawing methods:
+    especially in the common case where a single origin is used to draw
+    multiple lines or other primitives in succession to create more complex
+    shapes.
+
+    If a single origin is to be maintained, an application can take a 'snapshot'
+    of the cursor position using the [`save_origin`]
+    [lbutils.graphics.Canvas.save_origin] method before calling subsequent
+    drawing primitives . This snapshot of the drawing state can then be restored
+    to move the [`cursor`] [lbutils.graphics.helpers.BoundPixel] back to the
+    desired origin using the [`restore_origin`]
+    [lbutils.graphics.Canvas.restore_origin] method.
+
 ## Implementation
 
 The only methods _required_ to be implemented in sub-classes of [`Canvas`]

--- a/lbutils/graphics/__init__.py
+++ b/lbutils/graphics/__init__.py
@@ -29,26 +29,52 @@ description therefore describes the methods and attributes common to all derived
 drivers: but see the individual drivers for attributes and methods that may be
 specific to the device in question.
 
-Much of the functionality of the `Canvas` class is provided by related
-'helper' classes. Some of these helper classes such as [`Pen`]
-[lbutils.graphics.Pen] or [`Colour`][lbutils.graphics.Colour] may be useful
-more widely in graphics and drawing routines. Other helper classes such as
-the [`BaseFont`][lbutils.graphics.fonts.BaseFont] are likely to be useful
-only in the context of the `Canvas` class (and sub-classes).
+### User and Library Cursors
 
-As above, the main aim of the `Canvas` class (and the graphics library generally
-is to provide a basic set of capabilities which can be relied on by all users (and
-higher-level libraries). Those common facilities can be divided into the following
-categories, and are described in more detail in the following sections
+The `Canvas` will maintain two internal drawing references
+
+1. A [`cursor`]
+[lbutils.graphics.Canvas.cursor], representing the current
+[`x`][lbutils.graphics.Canvas.x] and [`y`][lbutils.graphics.Canvas.y]
+drawing co-ordinates. This [`cursor`]
+[lbutils.graphics.Canvas.cursor] should be assumed to be under the
+control of the _library_ (`Canvas`). For instance, many of the drawing methods,
+this internal state will be modified to point to the _next_ location which is
+commonly used in sequence. For example the [`write_text`]
+[lbutils.graphics.Canvas.write_text] updates the [`cursor`]
+[lbutils.graphics.Canvas.cursor] to point to position at the end of the text
+string. Or the [`draw_line`] [lbutils.graphics.Canvas.draw_line] method will
+change the [`cursor`] [lbutils.graphics.Canvas.cursor] to the end of the
+line just drawn. This behaviour makes it easier to sequence multiple drawing
+methods: especially in the common case where a single origin is used to draw
+multiple lines or other primitives in succession to create more complex shapes.
+2. An [`origin`]
+[lbutils.graphics.Canvas.origin], representing a reference point for
+a sequence of drawing commands or drawing primitives. This [`origin`]
+[lbutils.graphics.Canvas.origin] is assumed to be under the control of
+the _user_, and will usually _not_ be modified by the internal drawing commands.
+Instead an application can set the [`origin`]
+[lbutils.graphics.Canvas.origin], then use the drawing primitives with the
+addition of `from_origin` in the method name. Any internal change of state in
+the [`cursor`]
+[lbutils.graphics.Canvas.cursor] will not be reflected in a subsequent change
+to the origin.
+
+### Library Organisation and Helper Classes
+
+The main aim of the `Canvas` class (and the graphics library generally is to
+provide a basic set of capabilities which can be relied on by all users (and
+higher-level libraries). Those common facilities can be divided into the
+following categories, and are described in more detail in the following sections
 
 * **[Colour Support and Representation][lbutils.graphics.colours]**. Classes
 such as `Colour` which holds the internal colour representations used by the
 graphics library. Also provides methods to convert between common colour formats
 and representations, such as RGB565 and RGB588.
-* **[Common Drawing Primitives][lbutils.graphics.canvas]**. The drawing primitives
-provided by the `Canvas` class of the library, such as circles, rectangles and
-lines. These primitives are guaranteed to be available in all graphics drivers:
-but depending on the driver may or may not be accelerated,
+* **[Common Drawing Primitives][lbutils.graphics.Canvas]**. The drawing
+primitives provided by the `Canvas` class of the library, such as circles,
+rectangles and lines. These primitives are guaranteed to be available in all
+graphics drivers: but depending on the driver may or may not be accelerated.
 * **[Fonts and Font Handling][lbutils.graphics.fonts]**. Describes the internal
 font representation used in this library, and the details of the fonts available
 for use.
@@ -58,32 +84,15 @@ functions which ease the abstraction of the main graphics Canvas library, e.g.
 class as being the most suitable classes for re-use in other drawing and graphics
 routines.
 
-!!! Note "Drawing Side-Effects"
-    The `Canvas` will also maintain an internal [`cursor`]
-    [lbutils.graphics.helpers.BoundPixel], representing the current
-    [`x`][lbutils.graphics.Canvas.x] and [`y`][lbutils.graphics.Canvas.y]
-    drawing co-ordinates. For many of the above methods, this internal state
-    will be modified to point to the _next_ location which
-    is commonly used in sequence. For example the
-    [`write_text`][lbutils.graphics.Canvas.write_text] updates the
-    [`cursor`][lbutils.graphics.helpers.BoundPixel] to point to position at the
-    end of the text string. Or the [`draw_line`]
-    [lbutils.graphics.Canvas.draw_line] method will change the [`cursor`]
-    [lbutils.graphics.helpers.BoundPixel] to the end of the line just drawn.
-    This behaviour makes it easier to sequence multiple drawing methods:
-    especially in the common case where a single origin is used to draw
-    multiple lines or other primitives in succession to create more complex
-    shapes.
-
-    If a single origin is to be maintained, an application can take a 'snapshot'
-    of the cursor position using the [`save_origin`]
-    [lbutils.graphics.Canvas.save_origin] method before calling subsequent
-    drawing primitives . This snapshot of the drawing state can then be restored
-    to move the [`cursor`] [lbutils.graphics.helpers.BoundPixel] back to the
-    desired origin using the [`restore_origin`]
-    [lbutils.graphics.Canvas.restore_origin] method.
-
 ## Implementation
+
+Much of the functionality of the [`Canvas`]
+[lbutils.graphics.Canvas] class is provided by related
+'helper' classes. Some of these helper classes such as [`Pen`]
+[lbutils.graphics.Pen] or [`Colour`][lbutils.graphics.Colour] may be useful
+more widely in graphics and drawing routines. Other helper classes such as
+the [`BaseFont`][lbutils.graphics.fonts.BaseFont] are likely to be useful
+only in the context of the `Canvas` class (and sub-classes).
 
 The only methods _required_ to be implemented in sub-classes of [`Canvas`]
 [lbutils.graphics.Canvas] are [`read_pixel`][lbutils.graphics.Canvas.read_pixel]
@@ -95,6 +104,17 @@ and so in _most_ cases sub-classes will also choose to override methods such as
 available. The details of the accelerated methods, including any changes to the
 algorithms used by [`Canvas`][lbutils.graphics.Canvas] can be found in the
 documentation for the sub-class itself.
+
+!!! Note "Sub-Classes Should Ignore `from_origin` Methods"
+    Even for sub-classes which choose to `override` (i.e. re-implement) methods
+    from the `Canvas`, it is recommended _not_ to override the equivalent method
+    with the `from_origin` tag. For instance, sub-classes that re-implement the
+    [`draw_line`][lbutils.graphics.Canvas.draw_line] method _should not_ also
+    re-implement the [`draw_line_from_origin`]
+    [lbutils.graphics.Canvas.draw_line_from_origin] method. Internally the
+    `from_origin` methods will also call the 'normal' methods when drawing, so
+    any accelerated implementation for the 'normal' methods should automatically
+    apply to both.
 
 ## Tested Implementations
 

--- a/lbutils/graphics/__init__.py
+++ b/lbutils/graphics/__init__.py
@@ -104,6 +104,6 @@ documentation for the sub-class itself.
 ### Expose the `graphics` module interface as a full package
 __all__ = ["colours", "canvas", "helpers"]
 
-from .colours import Colour
-from .canvas import Canvas, FrameBufferCanvas
+from .colours import DEVICE_BIT_ORDER, Colour
+from .canvas import RECTANGLE_STYLE, Canvas, FrameBufferCanvas
 from .helpers import Pen, Pixel, BoundPixel

--- a/lbutils/graphics/__init__.py
+++ b/lbutils/graphics/__init__.py
@@ -105,17 +105,6 @@ available. The details of the accelerated methods, including any changes to the
 algorithms used by [`Canvas`][lbutils.graphics.Canvas] can be found in the
 documentation for the sub-class itself.
 
-!!! Note "Sub-Classes Should Ignore `from_origin` Methods"
-    Even for sub-classes which choose to `override` (i.e. re-implement) methods
-    from the `Canvas`, it is recommended _not_ to override the equivalent method
-    with the `from_origin` tag. For instance, sub-classes that re-implement the
-    [`draw_line`][lbutils.graphics.Canvas.draw_line] method _should not_ also
-    re-implement the [`draw_line_from_origin`]
-    [lbutils.graphics.Canvas.draw_line_from_origin] method. Internally the
-    `from_origin` methods will also call the 'normal' methods when drawing, so
-    any accelerated implementation for the 'normal' methods should automatically
-    apply to both.
-
 ## Tested Implementations
 
 *   Raspberry Pi Pico W (MicroPython 3.4)

--- a/lbutils/graphics/canvas.py
+++ b/lbutils/graphics/canvas.py
@@ -427,11 +427,14 @@ class Canvas(ABC):
         fg_colour: Type[graphics.Colour] = None,
         pen: Type[graphics.Pen] = None,
     ) -> None:
-        """Draw a line from the current `cursor` co-ordinates the point (`x2`,
-        `y2`) using the specified RGB colour. If the drawing colour is not
-        specified in the arguments to this method, then it will use the
-        preference order for the foreground colour of the `Canvas` Class to find
-        a suitable colour.
+        """Draw a line from the current `cursor` co-ordinates or the co-ordinate
+        specified in `start`, to the point given in the `end` co-ordinates and
+        using the specified RGB colour. If the drawing colour is not specified
+        in the arguments to this method, then it will use the preference order
+        for the foreground colour of the `Canvas` Class to find a suitable
+        colour. See [`select_fg_color`]
+        [lbutils.graphics.Canvas.select_fg_color] for more details of the
+        foreground colour selection algorithm.
 
         Example
         -------
@@ -510,8 +513,18 @@ class Canvas(ABC):
         style: RECTANGLE_STYLE = "FILLED",
     ) -> None:
         """Draw a rectangle at the co-ordinate (`x`, `y`) of `height` and
-        `width`, using the `linecolour` for the frame of the rectangle and
-        `fillcolour` as the interior colour.
+        `width`, using the either the specified or `Canvas` `fg_colour` for the
+        frame of the rectangle. If the `style` is `"FILLED"` then  either the
+        specified `bg_colour` or `Canvas` `bg_color` as the interior colour. If
+        the `style` is `"FRAMED"` then the interior of the rectangle is not
+        drawn.
+
+        See either [`select_fg_color`]
+        [lbutils.graphics.Canvas.select_fg_color] for more details of the
+        foreground colour selection algorithm; or [`select_bg_color`]
+        [lbutils.graphics.Canvas.select_bg_color] for more details of the
+        background colour selection algorithm. By default the rectangle is
+        `"FILLED"` and so both the background and foreground colours are used.
 
         Parameters
         ----------
@@ -663,7 +676,9 @@ class Canvas(ABC):
     def fill_screen(self, bg_colour: Type[graphics.Colour] = None) -> None:
         """Fill the entire display with the specified colour. By default this
         will use the colour preference order to find a background colour if
-        `bg_colour` is `None`.
+        `bg_colour` is `None`. See [`select_bg_color`]
+        [lbutils.graphics.Canvas.select_bg_color] for more details of the
+        background colour selection algorithm.
 
         Parameters
         ----------
@@ -688,12 +703,17 @@ class Canvas(ABC):
     def write_text(
         self,
         txt_str: str,
+        start: tuple = None,
         fg_colour: Type[graphics.Colour] = None,
         pen: Type[graphics.Pen] = None,
     ) -> None:
         """Write the string `txt_str` (using the current `font`) starting at the
-        the pixel position (`x`, `y`) of the `cursor` in the specified `colour`
-        to the display.
+        the pixel position (`x`, `y`) specified either by the `cursor` (the
+        default) or the `start` tuple. The text string is then written in the
+        specified `fg_colour`, or selected from the `Canvas` `fg_colour`, to the
+        display. See
+        [`select_fg_color`][lbutils.graphics.Canvas.select_fg_color] for more
+        details of the colour selection algorithm.
 
         !!! note
              Whilst the `txt_str` character _must_ be a valid UTF-8 string, most
@@ -707,6 +727,14 @@ class Canvas(ABC):
 
         txt_str:
              The string of characters to write to the display.
+        start: tuple, optional
+             The (x, y) co-ordinate of the _start_ point of the character, with
+             the first value of the `tuple` representing the `x` co-ordinate and
+             the second value of the `tuple` representing the `y` co-ordinate. If
+             the `start` is `None`, the default, then the current value of the
+             [`cursor`][lbutils.graphics.Canvas.cursor] is used as the start
+             point of the character. Values beyond the first and second entries
+             of the `tuple` are ignored.
         fg_colour: Type[graphics.Colour], optional
              The [`Colour`][lbutils.graphics.Colour] to be used when drawing the
              line. If not specified, use the preference order for the foreground
@@ -728,11 +756,14 @@ class Canvas(ABC):
     def write_char(
         self,
         utf8Char: str,
+        start: tuple = None,
         fg_colour: Type[graphics.Colour] = None,
         pen: Type[graphics.Pen] = None,
     ) -> None:
         """Write a `utf8Char` character (using the current `font`) starting at
         the pixel position (`x`, `y`) of the `cursor` in the specified `colour`.
+        See [`select_fg_color`][lbutils.graphics.Canvas.select_fg_color] for
+        more details of the colour selection algorithm.
 
         !!! note
             Whilst the `utf8Char` character _must_ be a valid UTF-8 character,
@@ -746,6 +777,14 @@ class Canvas(ABC):
 
         utf8Char:
             The character to write to the display.
+        start: tuple, optional
+             The (x, y) co-ordinate of the _start_ point of the character, with
+             the first value of the `tuple` representing the `x` co-ordinate and
+             the second value of the `tuple` representing the `y` co-ordinate. If
+             the `start` is `None`, the default, then the current value of the
+             [`cursor`][lbutils.graphics.Canvas.cursor] is used as the start
+             point of the character. Values beyond the first and second entries
+             of the `tuple` are ignored.
         fg_colour: Type[graphics.Colour], optional
             The [`Colour`][lbutils.graphics.Colour] to be used when drawing the
             character. If not specified, use the preference order for the
@@ -770,42 +809,6 @@ class Canvas(ABC):
                         fg_colour,
                     )
         self.cursor.x += _cursor
-
-    ##
-    ## Drawing Primitives using the `origin`
-    ##
-
-    def draw_line_from_origin(
-        self,
-        x: int,
-        y: int,
-        fg_colour: Type[graphics.Colour] = None,
-        pen: Type[graphics.Pen] = None,
-    ) -> None:
-        """Draw a line from the users `origin` co-ordinates the point (`x2`,
-        `y2`) using the specified RGB colour. If the drawing colour is not
-        specified in the arguments to this method, then it will use the
-        preference order for the foreground colour of the `Canvas` Class to find
-        a suitable colour.
-
-        Parameters
-        ----------
-
-        x: int
-             The X co-ordinate of the pixel for the end point of the line.
-        y: int
-             The Y co-ordinate of the pixel for the end point of the line.
-        fg_colour: Type[graphics.Colour], optional
-             The [`Colour`][lbutils.graphics.Colour] to be used when drawing the
-             line. If not specified, use the preference order for the foreground
-             colour of the `Canvas` to find a suitable colour.
-        pen: Type[graphics.Pen], optional
-             The [`Pen`][lbutils.graphics.Pen] to be used when drawing the line.
-             If not specified, use the preference order for the foreground colour
-             of the `Canvas` to find a suitable colour.
-        """
-        self.cursor = self.origin
-        self.draw_line(x, y, fg_colour, pen)
 
     ##
     ## utility Methods

--- a/lbutils/graphics/canvas.py
+++ b/lbutils/graphics/canvas.py
@@ -177,6 +177,14 @@ class Canvas(ABC):
     * `read_pixel()`. Return the [`Colour`][lbutils.graphics.colours.Colour] of
     the specified pixel.
 
+    * `restore_origin()`. Restore the current value of the [`cursor`]
+    [lbutils.graphics.helpers.BoundPixel] to a previously saved value. This
+    save value is set with `save_origin()`.
+
+    * `save_origin()`. Save the current value of the [`cursor`]
+    [lbutils.graphics.helpers.BoundPixel]. Can be restored with
+    `restore_origin()`.
+
     * `write_char()`. Write a character (using the current font) starting at the
     stated pixel position.
 
@@ -564,6 +572,22 @@ class Canvas(ABC):
             to an integer.
         """
         self.cursor.x_y = xy
+
+    def restore_origin(self) -> None:
+        """Restore the current value of the [`cursor`]
+        [lbutils.graphics.helpers.BoundPixel] to a previously saved value.
+
+        This saved value is set with [`save_origin`][lbutils.graphics.Canvas.save_origin].
+        """
+        self.cursor.x_y = self.origin
+
+    def save_origin(self) -> None:
+        """Save the current value of the [`cursor`]
+        [lbutils.graphics.helpers.BoundPixel].
+
+        Can be restored with [`restore_origin`][lbutils.graphics.Canvas.restore_origin].
+        """
+        self.origin = self.cursor.x_y
 
     def write_text(
         self,

--- a/lbutils/graphics/colours.py
+++ b/lbutils/graphics/colours.py
@@ -74,6 +74,15 @@ shown below
 """
 
 ###
+### Enumerations. MicroPython doesn't have actual an actual `enum` (yet), so
+### these serve as common cases where a selection of values need to be defined
+###
+
+DEVICE_BIT_ORDER = {"ARM", "INTEL"}
+"""Set the bit order to be used (mostly in graphics code) for low-level
+manipulation of bits send to, and received from, devices."""
+
+###
 ### Classes
 ###
 
@@ -100,10 +109,10 @@ class Colour:
         Provides the colour value in the RGB888 format, using a
         double word for the colour value in the standard platform
         representation.
-    isARM: bool, read-write
-        Flag indicating if the colour value should use the ARM byte
-        packing order in colour conversions. Defaults to `True` as
-        set by the default constructor.
+    bit_order: DEVICE_BIT_ORDER, read-write
+        Argument indicating if the underlying bit order used for
+        the bit packing order in colour conversions. Defaults to
+        `ARM` as set by the default constructor.
 
     Implementation
     --------------
@@ -122,7 +131,9 @@ class Colour:
     ## Constructors
     ##
 
-    def __init__(self, r: int, g: int, b: int, isARM: bool = True) -> None:
+    def __init__(
+        self, r: int, g: int, b: int, bit_order: DEVICE_BIT_ORDER = "ARM"
+    ) -> None:
         """Creates a representation of a colour value, from the three integers
         `r` (red), `g` (green) and `b` (blue). The class will accept anything
         which can be coerced to an integer as arguments: the access through the
@@ -138,17 +149,16 @@ class Colour:
             The integer representing the green component of the colour.
         b: int
             The integer representing the blue component of the colour.
-        isARM: bool, optional
-            Determines if the current platform is an ARM processor or not. This
-            value is used to determine which order for the `word` representation
-            of the colour returned to the caller. Defaults to `True` as required
-            by the Pico H/W platform of the micro-controller development board.
+        bit_order: DEVICE_BIT_ORDER, read-write
+            Argument indicating if the underlying bit order used for
+            the bit packing order in colour conversions. Defaults to
+            `ARM` as set by the default constructor.
         """
         self._r = int(r)
         self._g = int(g)
         self._b = int(b)
 
-        self.isARM = isARM
+        self.bit_order = "ARM"
 
         # Cached values
         self._565 = None
@@ -218,7 +228,7 @@ class Colour:
         if self._565 is None:
             # ... if there isn't one, calculate what the byte representation
             #     should look like
-            if self.isARM:
+            if self.bit_order == "ARM":
                 self._565 = (
                     (self._g & 0x1C) << 1
                     | (self._b >> 3)
@@ -263,7 +273,7 @@ class Colour:
         if self._888 is None:
             # ... if there isn't one, calculate what the byte representation
             #     should look like
-            if self.isARM:
+            if self.bit_order == "ARM":
                 self._888 = (
                     (self._g & 0x1C) << 1
                     | (self._b >> 3)

--- a/lbutils/graphics/helpers.py
+++ b/lbutils/graphics/helpers.py
@@ -38,6 +38,9 @@ try:
 except ImportError:
     from lbutils.typing import Type
 
+# Import the math library (needed for polar co-ordinates)
+from math import cos, sin
+
 from .colours import COLOUR_WHITE, COLOUR_BLACK, Colour
 
 ###
@@ -135,7 +138,12 @@ class Pixel:
     Methods
     ----------
 
-    * `move_to()`. Move the internal co-ordinate to the value (x, y).
+    * `move_to()`. Move the internal co-ordinate to the value (x, y). An alias
+    for the [`x_y`][lbutils.graphics.Pixel.x_y] property.
+    * `offset()`. Returns a `tuple` representing the (x, y) co-ordinate of the
+    current `Pixel` with the specified Cartesian off-set applied.
+    * `offset_polar()`. Returns a `tuple` representing the (x, y) co-ordinate of
+    the current `Pixel` with the specified Polar off-set applied.
     """
 
     ##
@@ -152,7 +160,7 @@ class Pixel:
         x: int
                 The initial X co-ordinate value.
         y: int
-                The initial Y co-ordinate value
+                The initial Y co-ordinate value.
         """
         self.x = int(x)
         self.y = int(y)
@@ -211,6 +219,107 @@ class Pixel:
             to an integer.
         """
         self.x_y = xy
+
+    def offset(self, x: int = 0, y: int = 0) -> tuple:
+        """Returns a `tuple` representing the (x, y) co-ordinate of the current
+        `Pixel` with the specified Cartesian off-set applied.
+
+        Example
+        -------
+
+        Given a `Pixel` object called `origin` with representing the co-ordinates
+        '(0, 10)'
+
+        ````python
+        origin = Pixel(0, 10)
+        ````
+
+        then calling
+
+        ````python
+        new_origin = origin.offset(10, 10)
+        ````
+
+        or better
+
+        ````python
+        new_origin = origin.offset(x = 10, y = 10)
+        ````
+
+        will return the tuple `[10, 20]` as `new_origin`.
+
+        Parameters
+        ----------
+
+        x: int, optional
+            The offset to apply to the x co-ordinate value of the `Pixel`.
+        y: int, optional
+            The offset to apply to the x co-ordinate value of the `Pixel`.
+
+        Returns
+        -------
+
+        tuple:
+            The (x, y) co-ordinate as a two value `tuple`  with the
+            first value of the `tuple` representing the `x` co-ordinate and the
+            second value of the `tuple` representing the `y` co-ordinate.
+        """
+        return [self.x + x, self.y + y]
+
+    def offset_polar(self, r: int = 0, theta: int = 0) -> tuple:
+        """Returns a `tuple` representing the (x, y) co-ordinate of the current
+        `Pixel` with the specified Polar off-set applied as the radius `r` and
+        angle `theta`.
+
+        !!! Note "Floating Point Calculations"
+            Although the _return_ values of the `offset_polar` function will be
+            integers, floating point routines are used internally to calculate
+            the sine and cosine of the angle `theta`. This may result in this
+            routine being slower than expected on some platforms.
+
+        Example
+        -------
+
+        Given a `Pixel` object called `origin` with representing the co-ordinates
+        '(0, 10)'
+
+        ````python
+        origin = Pixel(0, 10)
+        ````
+
+        then calling
+
+        ````python
+        new_origin = origin.offset_polar(13, 22)
+        ````
+
+        or better
+
+        ````python
+        new_origin = origin.offset(r = 13, theta = 22)
+        ````
+
+        will return the tuple `[12, 5]` as `new_origin`.
+
+        Parameters
+        ----------
+
+        r: int, optional
+            The offset to apply to the x co-ordinate value of the `Pixel`,
+            specified as the _radius_ of the Polar co-ordinate.
+        theta: int, optional
+            The offset to apply to the x co-ordinate value of the `Pixel`,
+            specified as the _angle_ of the Polar co-ordinate.
+
+        Returns
+        -------
+
+        tuple:
+            The (x, y) co-ordinate as a two value `tuple`  with the
+            first value of the `tuple` representing the `x` co-ordinate and the
+            second value of the `tuple` representing the `y` co-ordinate.
+        """
+        return [int(self.x + (r * cos(theta))), int(self.y + (r * sin(theta)))]
 
 
 class BoundPixel(Pixel):
@@ -297,9 +406,9 @@ class BoundPixel(Pixel):
         --------------
 
         As the `x` and `y` attributes of this class are compared on each write,
-        this class is by definition slower and potentially more resource intensive that
-        the underlying `Pixel` class. If the costs of the bounds-check are not required,
-        using the 'raw' `Pixel` class may be preferable.
+        this class is by definition slower and potentially more resource
+        intensive that the underlying `Pixel` class. If the costs of the bounds-
+        check are not required, using the 'raw' `Pixel` class may be preferable.
 
         !!! note
                 The parameter order is specified to allow easier definition
@@ -348,14 +457,10 @@ class BoundPixel(Pixel):
         if self.min_x <= value <= self.max_x:
             self._x = value
         else:
-            if self.clip:
-                if value > self.max_x:
-                    self._x = self.max_x
-                if value < self.min_x:
-                    self._x = self.min_x
-
-            else:
-                raise (ValueError("Pixel limits exceeded"))
+            if value > self.max_x:
+                self._x = self.max_x
+            if value < self.min_x:
+                self._x = self.min_x
 
     @property
     def y(self) -> int:
@@ -380,11 +485,7 @@ class BoundPixel(Pixel):
         if self.min_y <= value <= self.max_y:
             self._y = value
         else:
-            if self.clip:
-                if value > self.max_y:
-                    self._y = self.max_y
-                if value < self.min_y:
-                    self._y = self.min_y
-
-            else:
-                raise (ValueError("Pixel limits exceeded"))
+            if value > self.max_y:
+                self._y = self.max_y
+            if value < self.min_y:
+                self._y = self.min_y

--- a/lbutils/graphics/helpers.py
+++ b/lbutils/graphics/helpers.py
@@ -52,7 +52,7 @@ class Pen:
     colour and line values; for instance using two pens to allow a swap between
     'highlight' and 'normal' text colours. This can be accomplished by defining
     the foreground and background colour of the
-    [`Canvas`][lbutils.graphics.canvas] as needed: this class simply makes that
+    [`Canvas`][lbutils.graphics.Canvas] as needed: this class simply makes that
     switch easier.
 
     Example
@@ -114,7 +114,7 @@ class Pixel:
     origin where lines are being drawn to and from.
 
     !!! note "Implementation Defined Origin"
-            As for the [`Canvas`][lbutils.graphics.canvas] class, the
+            As for the [`Canvas`][lbutils.graphics.Canvas] class, the
             interpretation of the point '(0, 0)' is defined by the underlying
             graphics implementation. For instance the '(0, 0)' point may
             represent the top-left corner or the canvas, or the bottom- left hand
@@ -229,7 +229,7 @@ class BoundPixel(Pixel):
     values cannot lie outside the clipped region.
 
     !!! note "Implementation Defined Origin"
-            As for the [`Canvas`][lbutils.graphics.canvas] class, the
+            As for the [`Canvas`][lbutils.graphics.Canvas] class, the
             interpretation of the point '(0, 0)' is defined by the underlying
             graphics implementation. For instance the '(0, 0)' point may
             represent the top-left corner or the canvas, or the bottom- left hand

--- a/lbutils/graphics/helpers.py
+++ b/lbutils/graphics/helpers.py
@@ -38,7 +38,7 @@ try:
 except ImportError:
     from lbutils.typing import Type
 
-from .colours import Colour, COLOUR_WHITE, COLOUR_BLACK
+from .colours import COLOUR_WHITE, COLOUR_BLACK, Colour
 
 ###
 ### Classes
@@ -223,10 +223,10 @@ class BoundPixel(Pixel):
 
     Unlike the [`Pixel`][lbutils.graphics.Pixel] class, the `BoundPxiel` will
     also ensure that the X and Y co-ordinates are maintained between minimum and
-    maximum value for the `width` or `height`. This is useful for instances where a
-    cursor, for instance, must only take values within the limits of a display. It
-    can also be used where a clipping region is being defined to ensure that values
-    cannot lie outside the clipped region.
+    maximum value for the `width` or `height`. This is useful for instances where
+    a cursor, for instance, must only take values within the limits of a display.
+    It can also be used where a clipping region is being defined to ensure that
+    values cannot lie outside the clipped region.
 
     !!! note "Implementation Defined Origin"
             As for the [`Canvas`][lbutils.graphics.canvas] class, the
@@ -268,7 +268,6 @@ class BoundPixel(Pixel):
         max_y: int,
         min_x: int = 0,
         min_y: int = 0,
-        clip: bool = True,
     ) -> None:
         """Creates a `Pixel` instance holding the specified `x` and `y` co-
         ordinates, together representing the Cartesian point '(`x`, `y`)'. This
@@ -293,11 +292,6 @@ class BoundPixel(Pixel):
         min_y: int, optional
                 The minimum value allowed for the `y` co-ordinate. Defaults to
                 `0`.`
-        clip: bool, optional
-                If set to `True`, the default, silently clip the `x` and `y` co-
-                ordinates to the specified limits. If set to `False`, instead
-                raise a `ValueError` if the `x` or `y` co-ordinates do not fall
-                into the allowed limits.
 
         Implementation
         --------------
@@ -327,9 +321,6 @@ class BoundPixel(Pixel):
         self.x = int(x)
         self.y = int(y)
 
-        # Set the clipping switch
-        self.clip = clip
-
     ##
     ## Properties
     ##
@@ -339,25 +330,18 @@ class BoundPixel(Pixel):
         """The `x` co-ordinate of the `BoundPxiel`, checking that it lies within
         the specified `min_x` and `max_x` limits.
 
-        Raises
-        ------
-
-        `ValueError`:
-                If `clip` is set to `False`
+        If the `x` co-ordinate does lie outside the specified region, set it to
+        the `min_x` or `max_x` limit as appropriate.
         """
         if self.min_x <= self._x <= self.max_x:
             return self._x
         else:
-            if self.clip:
-                if self._x > self.max_x:
-                    self._x = self.max_x
-                if self._x < self.min_x:
-                    self._x = self.min_x
+            if self._x > self.max_x:
+                self._x = self.max_x
+            if self._x < self.min_x:
+                self._x = self.min_x
 
-                return self._x
-
-            else:
-                raise (ValueError("Pixel limits exceeded"))
+            return self._x
 
     @x.setter
     def x(self, value: int) -> None:
@@ -378,25 +362,18 @@ class BoundPixel(Pixel):
         """The `y` co-ordinate of the `BoundPxiel`, checking that it lies within
         the specified `min_x` and `max_y` limits.
 
-        Raises
-        ------
-
-        `ValueError`:
-                If `clip` is set to `False`
+        If the `y` co-ordinate does lie outside the specified region, set it to
+        the `min_y` or `may_y` limit as appropriate.
         """
         if self.min_y <= self._y <= self.max_y:
             return self._y
         else:
-            if self.clip:
-                if self._y > self.max_y:
-                    self._y = self.max_y
-                if self._y < self.min_y:
-                    self._y = self.min_y
+            if self._y > self.max_y:
+                self._y = self.max_y
+            if self._y < self.min_y:
+                self._y = self.min_y
 
-                return self._y
-
-            else:
-                raise (ValueError("Pixel limits exceeded"))
+            return self._y
 
     @y.setter
     def y(self, value: int) -> None:

--- a/lbutils/pmods/spi/oledrgb.py
+++ b/lbutils/pmods/spi/oledrgb.py
@@ -538,11 +538,14 @@ class OLEDrgb(graphics.Canvas):
         fg_colour: Type[graphics.Colour] = None,
         pen: Type[graphics.Pen] = None,
     ) -> None:
-        """Draw a line from the current `cursor` co-ordinates the point (`x2`,
-        `y2`) using the specified RGB colour. If the drawing colour is not
-        specified in the arguments to this method, then it will use the
-        preference order for the foreground colour of the `Canvas` Class to find
-        a suitable colour.
+        """Draw a line from the current `cursor` co-ordinates or the co-ordinate
+        specified in `start`, to the point given in the `end` co-ordinates and
+        using the specified RGB colour. If the drawing colour is not specified
+        in the arguments to this method, then it will use the preference order
+        for the foreground colour of the `Canvas` Class to find a suitable
+        colour. See [`select_fg_color`]
+        [lbutils.graphics.Canvas.select_fg_color] for more details of the
+        foreground colour selection algorithm.
 
         Example
         -------

--- a/lbutils/pmods/spi/oledrgb.py
+++ b/lbutils/pmods/spi/oledrgb.py
@@ -136,49 +136,125 @@ _LOCK = const(0xFD)
 
 class OLEDrgb(graphics.Canvas):
     """An implemention of a [`Canvas`][lbutils.graphics.Canvas] for the
-    'OLEDrgb' PMod.
+    'OLEDrgb' PMod. This drawing support is provided through the following
+    categories of tools.
+
+    * **Drawing Primitives**: Provides basic support for drawing lines,
+    rectangles, circles and triangles. This serves as a basic collection of
+    primitives that can be relied upon by higher-level libraries.
+    * **Font Support**: The `Canvas` maintains a record of the current font to
+    use when writing text through the `font` attribute. This can be changed by
+    users of the library, and defaults to [`Org_01`]
+    [lbutils.graphics.fonts.Org_01].
+    * **Colour Support**: Colours can be selected in different ways, and the
+    `Canvas` maintains a foreground (`fg_color`) and background (`bg_color`)
+    attribute: along with a common method to override these default colours
+    quickly for individual drawing commands. Colours are selected by order of
+    precedence, which is defined as
+
+        1. The `Colour`s directly specified in the method call of the drawing
+        primitive.
+        2. The colours specified by the `Pen` in the method call of the drawing
+        primitive.
+        3. The colours specified by the `Pen` of the `Canvas` object.
+        4. The colours specified by as the default (forground or background)
+        colour of the `Canvas` object.
+        5. As a default of white (`COLOUR_WHITE`) for the foreground, and black
+        (`COLOUR_BLACK`) if all other selection methods fail.
 
     Attributes
     ----------
 
     bg_colour:
-        The background [`Colour`][lbutils.graphics.colours.Colour] to use when
-        drawing.
+         The background [`Colour`][lbutils.graphics.colours.Colour] to use when
+         drawing.
+    cursor:
+         The [`x`][lbutils.graphics.BoundPixel] and [`y`]
+         [lbutils.graphics.BoundPixel] locations  of the current write
+         (or read) operation.
+    origin:
+         The _user_ reference point for the next sequence of drawing primitives.
+         This `origin` will not be altered by changes to the [`x`]
+         [lbutils.graphics.BoundPixel] and [`y`]
+         [lbutils.graphics.BoundPixel] locations of any drawing command.
     font:
-        The sub-class of [`BaseFont`][lbutils.graphics.fonts.base_font.BaseFont]
-        to use when drawing characters.
+         The sub-class of [`BaseFont`][lbutils.graphics.fonts.base_font.BaseFont]
+         to use when drawing characters.
     fg_colour:
-        The foreground [`Colour`][lbutils.graphics.colours.Colour] to use when
-        drawing.
+         The foreground [`Colour`][lbutils.graphics.colours.Colour] to use when
+         drawing.
+    pen:
+         The [`Pen`][lbutils.graphics.Pen] to use when drawing on the canvas.
     height:
-        A read-only value for the height of the canvas in pixels.
+         A read-only value for the height of the canvas in pixels.
     width:
-        A read-only value for the width of the canvas in pixels.
+         A read-only value for the width of the canvas in pixels.
+    x: int
+            The X co-ordinate value of the `cursor`
+    y: int
+            The Y co-ordinate value of the `cursor`
+    x_y: int
+            A tuple representing the co-ordinate (x ,y) of the `cursor`
 
     Methods
     ----------
 
-    * `draw_line()`. Draw a line from two co-ordinates.
+    **Cursor and Origin Movements**
+
+    * `move_to()`. Move the internal [`cursor`]
+    [lbutils.graphics.Canvas.cursor]  to the co-ordinate values (x, y) for
+    the next sequence of drawing commands.
+
+    * `move_origin_to()`. Sets the user drawing [`origin`]
+    [lbutils.graphics.Canvas.origin] of the `Canvas` to the specified
+    co-ordinates for the next sequence of drawing commands.
+
+    **Colour Management**
+
+    * `select_bg_color()`. Return the colour to be used for drawing in the
+    background, taking into account the (optional) overrides specified in
+    `bg_color` and `pen`. The selected colour will obey the standard colour
+    selection precedence of the `Canvas` class, and is guaranteed to return a
+    valid [`Colour`][lbutils.graphics.colours.Colour] object.
+
+    * `select_fg_color()`. Return the colour to be used for drawing in the
+    foreground, taking into account the (optional) overrides specified in `color`
+    and `pen`. The selected colour will obey the standard colour selection
+    precedence of the `Canvas` class, and is guaranteed to return a valid
+    [`Colour`][lbutils.graphics.colours.Colour] object.
+
+    **Shape and Line Drawing Primitives**
+
+    * `draw_line()`. Draw a line from a specified point (by default the
+    [`cursor`][lbutils.graphics.Canvas.cursor]) to a co-ordinate.
+
+    * `draw_to()`. Draw a line from a specified point (by default the
+    [`cursor`][lbutils.graphics.Canvas.cursor]) to a co-ordinate. Alias for
+    [`draw_line()`][lbutils.graphics.Canvas.draw_line].
 
     * `draw_rectangle()`. Draw a rectangle at the co-ordinate (x, y) of height
-    and width, using the linecolour for the frame of the rectangle and fillcolour
-    as the interior colour.
+    and width, using the specified colours for the frame of the rectangle and
+    the interior fill colour (if any).
 
     * `fill_screen()`. Fill the entire `Canvas` with the background colour.
+
+    **Font and Text Handling**
+
+    * `write_char()`. Write a character (using the current font) starting at the
+    specified co-ordinates (by default the current [`cursor`]
+    [lbutils.graphics.Canvas.cursor] co-ordinates.), in the specified colour.
+
+    * `write_text()`. Write the a string (using the current font) starting at the
+    specified co-ordinates (by default the current [`cursor`]
+    [lbutils.graphics.Canvas.cursor] co-ordinates.), in the specified colour.
+
+    **Pixel Manipulation**
 
     * `read_pixel()`. Return the [`Colour`][lbutils.graphics.colours.Colour] of
     the specified pixel.
 
-    * `reset()`. Resets the display, clearing the current contents.
-
-    * `write_char()`. Write a character (using the current font) starting at the
-    stated pixel position.
-
     * `write_pixel()`. Set the pixel at the specified position to the foreground
     colour value.
-
-    * `write_text()`. Write the a string (using the current font) starting at the
-    specified pixel position in the specified colour.
     """
 
     _INIT = (
@@ -453,54 +529,124 @@ class OLEDrgb(graphics.Canvas):
         self._write(_SETROW, bytearray([y, y]))
 
         #          self._write(None,bytearray([colour >> 8, colour &0xff]))
-        self.draw_line(x, y, x, y)
+        self.draw_line(start=[x, y], end=[x, y])
 
     def draw_line(
         self,
-        x1: int,
-        y1: int,
-        x2: int,
-        y2: int,
+        end: tuple,
+        start: tuple = None,
         fg_colour: Type[graphics.Colour] = None,
         pen: Type[graphics.Pen] = None,
     ) -> None:
-        """Draw a line from co-ordinates (`x2`, `y2`) to (`x2`, `y2`) using the
-        specified RGB colour. If the `fg_colour` is `Nonw`, then the default
-        search order is used to locate a suitable colour.
+        """Draw a line from the current `cursor` co-ordinates the point (`x2`,
+        `y2`) using the specified RGB colour. If the drawing colour is not
+        specified in the arguments to this method, then it will use the
+        preference order for the foreground colour of the `Canvas` Class to find
+        a suitable colour.
+
+        Example
+        -------
+
+        If the method is called with the `start` co-ordinate as `None` then the
+        current value of the [`cursor`][lbutils.graphics.Canvas.cursor] will be
+        used. However the `end` co-ordinate _must_ be specified. This means that
+        in normal use the method can be called as
+
+        ````python
+        canvas.draw_line([0, 20])
+        ````
+
+        to draw a line from the current [`cursor`]
+        [lbutils.graphics.Canvas.cursor] to the co-ordinate '(0, 20)'. This will
+        also use the current [`fg_colour`][lbutils.graphics.Canvas.fg_colour] of
+        the canvas when drawing the line.
+
+        To change the line colour, either set the [`Pen`][lbutils.graphics.Pen],
+        or call the method with the colour set directly as
+
+        ````python
+        canvas.draw_line([0, 20], fg_colour = lbutils.graphics.COLOUR_NAVY)
+        ````
+
+        The start of the line to be drawn can be changed using the `start`
+        parameter: however in this case it is recommended to set _both_ the
+        `start` and the `end` as named parameters, e.g.
+
+        ````python
+        canvas.draw_line(start = [0, 0], end = [0, 20])
+        ````
+
+        Using named parameter makes it much more obvious to readers of the
+        library code which co-ordinates are being used to draw the line. Don't
+        rely on the readers of the code remembering the positional arguments.
 
         Parameters
         ----------
 
-        x1: int
-            The X co-ordinate of the pixel for the start point of the line.
-        y1: int
-            The Y co-ordinate of the pixel for the start point of the line.
-        x2: int
-            The X co-ordinate of the pixel for the end point of the line.
-        y2: int
-            The Y co-ordinate of the pixel for the end point of the line.
+        start: tuple
+             The (x, y) co-ordinate of the _start_ point of the line, with
+             the first value of the `tuple` representing the `x` co-ordinate and
+             the second value of the `tuple` representing the `y` co-ordinate. If
+             the `start` is `None`, the default, then the current value of the
+             [`cursor`][lbutils.graphics.Canvas.cursor] is used as the start
+             point of the line. Values beyond the first and second entries of
+             the `tuple` are ignored.
+        end: tuple
+             The (x, y) co-ordinate of the pixel for the _end_ point of the line,
+             with the first value of the tuple representing the `x` co-ordinate
+             and the second value of the tuple representing the `y` co-ordinate.
+             Values beyond the first and second entries of the `tuple` are
+             ignored.
         fg_colour: Type[graphics.Colour], optional
-            The [`Colour`][lbutils.graphics.Colour] to be used when drawing the
-            line. If not specified, use the preference order for the foreground
-            colour of the `Canvas` to find a suitable colour.
+             The [`Colour`][lbutils.graphics.Colour] to be used when drawing the
+             line. If not specified, use the preference order for the foreground
+             colour of the `Canvas` to find a suitable colour.
         pen: Type[graphics.Pen], optional
-            The [`Pen`][lbutils.graphics.Pen] to be used when drawing the line.
-            If not specified, use the preference order for the foreground colour
-            of the `Canvas` to find a suitable colour.
+             The [`Pen`][lbutils.graphics.Pen] to be used when drawing the line.
+             If not specified, use the preference order for the foreground colour
+             of the `Canvas` to find a suitable colour.
+
+        Raises
+        ------
+
+        ValueError:
+            If the `start` or `end` tuples cannot be correctly interpreted as
+            byte values; with the `x` co-ordinate as the first entry of the
+            `tuple` and the `y` co-ordinate as the second entry of the tuple.
         """
 
         fg_colour = self.select_fg_color(fg_colour=fg_colour, pen=pen)
 
-        data = ustruct.pack(
-            self._ENCODE_LINE,
-            x1,
-            y1,
-            x2,
-            y2,
-            fg_colour.bR,
-            fg_colour.bG,
-            fg_colour.bB,
-        )
+        try:
+            if start is None:
+                data = ustruct.pack(
+                    self._ENCODE_LINE,
+                    self.cursor.x,
+                    self.cursor.y,
+                    end[0],
+                    end[1],
+                    fg_colour.bR,
+                    fg_colour.bG,
+                    fg_colour.bB,
+                )
+            else:
+                data = ustruct.pack(
+                    self._ENCODE_LINE,
+                    start[0],
+                    start[1],
+                    end[0],
+                    end[1],
+                    fg_colour.bR,
+                    fg_colour.bG,
+                    fg_colour.bB,
+                )
+        except Exception:
+            raise ValueError(
+                "Invalid parameters has been passed to 'draw_line'. I cannot"
+                "interpret the co-ordinates passed as arguments: check the"
+                "'start' and 'end' tuples are correct"
+            )
+
         self._write(_DRAWLINE, data)
 
     def draw_rectangle(

--- a/lbutils/pmods/spi/oledrgb.py
+++ b/lbutils/pmods/spi/oledrgb.py
@@ -76,11 +76,11 @@ try:
 except ImportError:
     from lbutils.typing import Type
 
-    # Import the lbutils graphics library
-    # try:
+# Import the lbutils graphics library
+try:
     import lbutils.graphics as graphics
-# except ImportError:
-#    raise RuntimeError("Error: Missing required LBUtils graphics library")
+except ImportError:
+    raise RuntimeError("Error: Missing required LBUtils graphics library")
 
 # Import the core libraries
 import ustruct
@@ -338,7 +338,7 @@ class OLEDrgb(graphics.Canvas):
         """
 
         # Set the ancestor values
-        super().__init__(width, height, True)
+        super().__init__(width, height, "ARM")
 
         # Set the local attributes
         self.spi_controller = spi_controller
@@ -512,7 +512,7 @@ class OLEDrgb(graphics.Canvas):
         fg_colour: Type[graphics.Colour] = None,
         bg_colour: Type[graphics.Colour] = None,
         pen: Type[graphics.Pen] = None,
-        filled: bool = True,
+        style: graphics.RECTANGLE_STYLE = "FILLED",
     ) -> None:
         """Draw a rectangle at the co-ordinate (`x`, `y`) of `height` and
         `width`, using the `linecolour` for the frame of the rectangle and
@@ -543,16 +543,17 @@ class OLEDrgb(graphics.Canvas):
             background colour for the fill. If not specified, use the
             preference order for the foreground and background colours of the
             `Canvas` to find suitable colours.
-        filled: bool, optional
-            If `True` (the default) the rectangle is filled with the background
-            colour: otherwise the rectangle is not filled.
+        style: RECTANGLE_STYLE, optional
+             Set the style for the rectangle to draw. The defined style,
+             `FILLED`, sets the interior of the rectangle to the the
+             current background colour.
         """
 
         fg_colour = self.select_fg_color(fg_colour=fg_colour, pen=pen)
         bg_colour = self.select_bg_color(bg_colour=bg_colour, pen=pen)
 
         # Send the commands to fill, or not fill, the rectangle
-        if filled:
+        if style == "FILLED":
             self._write(_FILL, b"\x01")
         else:
             self._write(_FILL, b"\x00")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = ["lbutils", "lbutils.drivers", "lbutils.graphics", "lbutils.graphics.
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F"]
+select = ["E", "F", "Q", "FBT"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]


### PR DESCRIPTION
Give the user an easier method to specify the start of drawing commands, both for drawing primitives that must start from some common reference, and for ad-hoc changes. This introduces an `origin` to the `Canvas` class, which is under the user control. Also adds a Cartesian and Polar offset to the `Pixel` helper which allows small changes relative to the `Canvas` `cursor`, or to the user `origin`.