### PR TITLE
Add ruff checks

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,8 @@
+name: Ruff
+on: [ push, pull_request ]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: chartboost/ruff-action@v1

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,16 @@
 
 All releases should be on [PyPi](https://pypi.org/project/lbutils-mp/), and also published on [GitHub](https://github.com/dlove24/lbutils). A full log of the changes can be found in the source, or on GitHub: what follows is a summary of key features/changes.
 
+## 2023-04-16: lbutils 0.2.5
+
+### Changed
+
+* Updated the type signature of the library methods to make
+static type checking easier. Also added `mypy` to the commit 
+hook to enforce type checking, and updated the documentation
+to reflect the types of the module attributes in use more
+consistently.
+
 ## 2023-04-16: lbutils 0.2.4
 
 ### New

--- a/docs/ref/reference.md
+++ b/docs/ref/reference.md
@@ -20,9 +20,9 @@ Drivers for the display of a single digit
 ### Classes
 
 * [`BaseFont`][lbutils.graphics.fonts.BaseFont]. Base class, used  by the font display routines.
-* [`Font06`][lbutils.graphics.fonts.font06]. Six Pixel bitmap font.
-* [`Font08`][lbutils.graphics.fonts.font08]. Eight Pixel bitmap font.
-* [`Org_01`][lbutils.graphics.fonts.org_01]. Alternative bitmap font.
+* [`Font06`][lbutils.graphics.fonts.Font06]. Six Pixel bitmap font.
+* [`Font08`][lbutils.graphics.fonts.Font08]. Eight Pixel bitmap font.
+* [`Org01`][lbutils.graphics.fonts.Org01]. Alternative bitmap font.
 
 ::: lbutils.helpers
     options:

--- a/examples/drivers/__init__.py
+++ b/examples/drivers/__init__.py
@@ -1,0 +1,23 @@
+# This module, and all included code, is made available under the terms of the MIT
+# Licence
+#
+# Copyright 2022-2023, David Love
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Driver examples for `lbutils`."""

--- a/examples/drivers/seven_segment_example.py
+++ b/examples/drivers/seven_segment_example.py
@@ -63,8 +63,8 @@ seg_list2 = [10, 11, 12, 13, 14, 15, 16]
 
 # Create the seven-segment display objects, each attached to the relevant
 # segment using the `SegDisplay` driver class
-segDisp1 = SegDisplay(seg_list1)
-segDisp2 = SegDisplay(seg_list2)
+seg_display1 = SegDisplay(seg_list1)
+seg_display2 = SegDisplay(seg_list2)
 
 # Read the input value from ADC0 on GPIO Pin 26
 adc = ADC(26)
@@ -73,7 +73,7 @@ adc = ADC(26)
 while True:
     adcval = adc.read_u16()
     temp = hidden.measureval(adcval)
-    segDisp2.display(int(temp % 10))
-    segDisp1.display(int((temp / 10) % 10))
+    seg_display2.display(int(temp % 10))
+    seg_display1.display(int((temp / 10) % 10))
 
     utime.sleep(1)

--- a/examples/drivers/seven_segment_example.py
+++ b/examples/drivers/seven_segment_example.py
@@ -45,8 +45,8 @@ except ImportError:
 
 # Import required core libraries
 try:
-    import utime
     import hidden
+    import utime
 except ImportError:
     print("Missing core libraries")
 

--- a/examples/drivers/seven_segment_hex_example.py
+++ b/examples/drivers/seven_segment_hex_example.py
@@ -44,8 +44,8 @@ except ImportError:
 
 # Import required core libraries
 try:
-    import utime
     import hidden
+    import utime
 except ImportError:
     print("Missing core libraries")
 

--- a/examples/drivers/seven_segment_hex_example.py
+++ b/examples/drivers/seven_segment_hex_example.py
@@ -62,8 +62,8 @@ seg_list2 = [10, 11, 12, 13, 14, 15, 16]
 
 # Create the seven-segment display objects, each attached to the relevant
 # segment using the `SegHexDisplay` driver class
-segDisp1 = SegHexDisplay(seg_list1)
-segDisp2 = SegHexDisplay(seg_list2)
+seg_display1 = SegHexDisplay(seg_list1)
+seg_display2 = SegHexDisplay(seg_list2)
 
 # Read the input value from ADC0 on GPIO Pin 26
 adc = ADC(26)
@@ -72,7 +72,7 @@ adc = ADC(26)
 while True:
     adcval = adc.read_u16()
     temp = hidden.measureval(adcval)
-    segDisp2.display(int(temp % 16))
-    segDisp1.display(int((temp / 16) % 16))
+    seg_display2.display(int(temp % 16))
+    seg_display1.display(int((temp / 16) % 16))
 
     utime.sleep(1)

--- a/examples/pmod/__init__.py
+++ b/examples/pmod/__init__.py
@@ -1,0 +1,23 @@
+# This module, and all included code, is made available under the terms of the MIT
+# Licence
+#
+# Copyright 2022-2023, David Love
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""PMod examples for `lbutils`."""

--- a/examples/pmod/pmod_oled_example.py
+++ b/examples/pmod/pmod_oled_example.py
@@ -47,7 +47,7 @@ try:
     import lbutils.graphics.fonts as fonts
 except ImportError:
     raise RuntimeError(
-        "Error: Missing required LBUtils graphics library"
+        "Error: Missing required LBUtils graphics library",
     ) from ImportError
 
 # Import the LB Utils driver for the Pmod OLEDrgb
@@ -144,19 +144,24 @@ oled_display.fg_colour = graphics.colours.COLOUR_BLUE
 oled_display.font = fonts.Org01()
 
 oled_display.write_text(
-    start=oled_display.origin.offset(y=20), txt_str="ABCDEFGHIJKLMN"
+    start=oled_display.origin.offset(y=20),
+    txt_str="ABCDEFGHIJKLMN",
 )
 oled_display.write_text(
-    start=oled_display.origin.offset(y=30), txt_str="OPQRSTUVWXYZ   "
+    start=oled_display.origin.offset(y=30),
+    txt_str="OPQRSTUVWXYZ   ",
 )
 oled_display.write_text(
-    start=oled_display.origin.offset(y=40), txt_str="abcdefghijklmn "
+    start=oled_display.origin.offset(y=40),
+    txt_str="abcdefghijklmn ",
 )
 oled_display.write_text(
-    start=oled_display.origin.offset(y=50), txt_str="opqrstuvwxyz   "
+    start=oled_display.origin.offset(y=50),
+    txt_str="opqrstuvwxyz   ",
 )
 oled_display.write_text(
-    start=oled_display.origin.offset(y=60), txt_str="0123456789     "
+    start=oled_display.origin.offset(y=60),
+    txt_str="0123456789     ",
 )
 
 utime.sleep(10)

--- a/examples/pmod/pmod_oled_example.py
+++ b/examples/pmod/pmod_oled_example.py
@@ -91,10 +91,10 @@ oled_display.origin.x_y = [0, 0]
 
 # Display the `Font_08` font class in red, and set the cursor
 # of the `oled_display` manually each time.
-print("Running the screen test for the `Font_08` font...")
+print("Running the screen test for the `Font08` font...")
 
 oled_display.fg_colour = graphics.colours.COLOUR_RED
-oled_display.font = fonts.Font_08()
+oled_display.font = fonts.Font08()
 
 oled_display.x_y = [0, 20]
 oled_display.write_text("ABCDEFGHIJKLMN")
@@ -118,10 +118,10 @@ oled_display.fill_screen(graphics.colours.COLOUR_BLACK)
 
 # Display the `Font_06` font class in green, and set the cursor
 # at the start of each call to `write_text`
-print("Running the screen test for the `Font_06` font...")
+print("Running the screen test for the `Font06` font...")
 
 oled_display.fg_colour = graphics.colours.COLOUR_LIME
-oled_display.font = fonts.Font_06()
+oled_display.font = fonts.Font06()
 
 oled_display.write_text(start=[0, 20], txt_str="ABCDEFGHIJKLMN")
 oled_display.write_text(start=[0, 30], txt_str="OPQRSTUVWXYZ")
@@ -134,12 +134,12 @@ utime.sleep(10)
 # Clear the display
 oled_display.fill_screen(graphics.colours.COLOUR_BLACK)
 
-# Display the `Org_01` font class in blue, and use the origin
+# Display the `Org01` font class in blue, and use the origin
 # with an offset to display the text using `write_text`
-print("Running the screen test for the `Org_01` font...")
+print("Running the screen test for the `Org01` font...")
 
 oled_display.fg_colour = graphics.colours.COLOUR_BLUE
-oled_display.font = fonts.Org_01()
+oled_display.font = fonts.Org01()
 
 oled_display.write_text(
     start=oled_display.origin.offset(y=20), txt_str="ABCDEFGHIJKLMN"

--- a/examples/pmod/pmod_oled_example.py
+++ b/examples/pmod/pmod_oled_example.py
@@ -45,7 +45,7 @@ except ImportError:
 # Import the lbutils graphics library
 try:
     from lbutils import graphics
-    from lbutils.graphics import fonts
+    from lbutils.graphics import colours, fonts
 except ImportError:
     msg = ("Error: Missing required LBUtils graphics library",)
     raise RuntimeError(msg) from ImportError
@@ -73,7 +73,7 @@ chip_sel_pin = Pin(14, Pin.OUT)
 reset_pin = Pin(17, Pin.OUT)
 
 # Add the VCC_Enable pin, used to control the display
-# and display backlight, and set to `high()` to turn
+# and display back-light, and set to `high()` to turn
 # the display on
 vcc_enable = Pin(22, Pin.OUT)
 vcc_enable.high()
@@ -81,7 +81,7 @@ vcc_enable.high()
 # Finally initialise the OLED display driver, and set the display
 # to black
 oled_display = OLEDrgb(spi_controller, data_cmd_pin, chip_sel_pin, reset_pin)
-oled_display.fill_screen(graphics.colours.COLOUR_BLACK)
+oled_display.fill_screen(colours.COLOUR_BLACK)
 
 # Set the origin for the tests
 oled_display.origin.x_y = [0, 0]
@@ -96,7 +96,7 @@ oled_display.origin.x_y = [0, 0]
 # of the `oled_display` manually each time.
 print("Running the screen test for the `Font08` font...")
 
-oled_display.fg_colour = graphics.colours.COLOUR_RED
+oled_display.fg_colour = colours.COLOUR_RED
 oled_display.font = fonts.Font08()
 
 oled_display.x_y = [0, 20]
@@ -117,13 +117,13 @@ oled_display.write_text("0123456789")
 utime.sleep(10)
 
 # Clear the display
-oled_display.fill_screen(graphics.colours.COLOUR_BLACK)
+oled_display.fill_screen(colours.COLOUR_BLACK)
 
-# Display the `Font_06` font class in green, and set the cursor
+# Display the `Font06` font class in green, and set the cursor
 # at the start of each call to `write_text`
 print("Running the screen test for the `Font06` font...")
 
-oled_display.fg_colour = graphics.colours.COLOUR_LIME
+oled_display.fg_colour = colours.COLOUR_LIME
 oled_display.font = fonts.Font06()
 
 oled_display.write_text(start=[0, 20], txt_str="ABCDEFGHIJKLMN")
@@ -135,13 +135,13 @@ oled_display.write_text(start=[0, 60], txt_str="0123456789")
 utime.sleep(10)
 
 # Clear the display
-oled_display.fill_screen(graphics.colours.COLOUR_BLACK)
+oled_display.fill_screen(colours.COLOUR_BLACK)
 
 # Display the `Org01` font class in blue, and use the origin
 # with an offset to display the text using `write_text`
 print("Running the screen test for the `Org01` font...")
 
-oled_display.fg_colour = graphics.colours.COLOUR_BLUE
+oled_display.fg_colour = colours.COLOUR_BLUE
 oled_display.font = fonts.Org01()
 
 oled_display.write_text(
@@ -176,7 +176,7 @@ for i in range(8):
     r = (i & 1) * 255
     g = ((i >> 1) & 1) * 255
     b = ((i >> 2) & 1) * 255
-    colors.append(graphics.colours.Colour(r, g, b))
+    colors.append(colours.Colour(r, g, b))
 
 print("Running the colour test...")
 while True:

--- a/examples/pmod/pmod_oled_example.py
+++ b/examples/pmod/pmod_oled_example.py
@@ -39,20 +39,22 @@ try:
     import framebuf
     from machine import SPI, Pin
 except ImportError:
-    raise RuntimeError("Error: Missing required MicroPython includes!")
+    raise RuntimeError("Error: Missing required MicroPython includes!") from ImportError
 
 # Import the lbutils graphics library
 try:
     import lbutils.graphics as graphics
     import lbutils.graphics.fonts as fonts
 except ImportError:
-    raise RuntimeError("Error: Missing required LBUtils graphics library")
+    raise RuntimeError(
+        "Error: Missing required LBUtils graphics library"
+    ) from ImportError
 
 # Import the LB Utils driver for the Pmod OLEDrgb
 try:
     from lbutils.pmods.spi import OLEDrgb
 except ImportError:
-    raise RuntimeError("Error: Cannot find the Pmod OLEDrgb driver!")
+    raise RuntimeError("Error: Cannot find the Pmod OLEDrgb driver!") from ImportError
 
 # Import the core libraries
 import utime

--- a/examples/pmod/pmod_oled_example.py
+++ b/examples/pmod/pmod_oled_example.py
@@ -44,8 +44,8 @@ except ImportError:
 
 # Import the lbutils graphics library
 try:
-    import lbutils.graphics as graphics
-    import lbutils.graphics.fonts as fonts
+    from lbutils import graphics
+    from lbutils.graphics import fonts
 except ImportError:
     msg = ("Error: Missing required LBUtils graphics library",)
     raise RuntimeError(msg) from ImportError

--- a/examples/pmod/pmod_oled_example.py
+++ b/examples/pmod/pmod_oled_example.py
@@ -39,22 +39,23 @@ try:
     import framebuf
     from machine import SPI, Pin
 except ImportError:
-    raise RuntimeError("Error: Missing required MicroPython includes!") from ImportError
+    msg = "Error: Missing required MicroPython includes!"
+    raise RuntimeError(msg) from ImportError
 
 # Import the lbutils graphics library
 try:
     import lbutils.graphics as graphics
     import lbutils.graphics.fonts as fonts
 except ImportError:
-    raise RuntimeError(
-        "Error: Missing required LBUtils graphics library",
-    ) from ImportError
+    msg = ("Error: Missing required LBUtils graphics library",)
+    raise RuntimeError(msg) from ImportError
 
 # Import the LB Utils driver for the Pmod OLEDrgb
 try:
     from lbutils.pmods.spi import OLEDrgb
 except ImportError:
-    raise RuntimeError("Error: Cannot find the Pmod OLEDrgb driver!") from ImportError
+    msg = "Error: Cannot find the Pmod OLEDrgb driver!"
+    raise RuntimeError(msg) from ImportError
 
 # Import the core libraries
 import utime

--- a/examples/pmod/pmod_oled_example.py
+++ b/examples/pmod/pmod_oled_example.py
@@ -36,8 +36,8 @@ This version is written for MicroPython 3.4, and has been tested on:
 
 # Import the SPI, GPIO and framebuffer MicroPython libraries
 try:
-    from machine import Pin, SPI
     import framebuf
+    from machine import SPI, Pin
 except ImportError:
     raise RuntimeError("Error: Missing required MicroPython includes!")
 

--- a/examples/pmod/pmod_oled_flowers.py
+++ b/examples/pmod/pmod_oled_flowers.py
@@ -46,7 +46,7 @@ try:
     import lbutils.graphics.fonts as fonts
 except ImportError:
     raise RuntimeError(
-        "Error: Missing required LBUtils graphics library"
+        "Error: Missing required LBUtils graphics library",
     ) from ImportError
 
 # Import the LB Utils driver for the Pmod OLEDrgb

--- a/examples/pmod/pmod_oled_flowers.py
+++ b/examples/pmod/pmod_oled_flowers.py
@@ -35,8 +35,8 @@ This version is written for MicroPython 3.4, and has been tested on:
 
 # Import the SPI, GPIO and framebuffer MicroPython libraries
 try:
-    from machine import Pin, SPI
     import framebuf
+    from machine import SPI, Pin
 except ImportError:
     raise RuntimeError("Error: Missing required MicroPython includes!")
 

--- a/examples/pmod/pmod_oled_flowers.py
+++ b/examples/pmod/pmod_oled_flowers.py
@@ -38,22 +38,23 @@ try:
     import framebuf
     from machine import SPI, Pin
 except ImportError:
-    raise RuntimeError("Error: Missing required MicroPython includes!") from ImportError
+    msg = "Error: Missing required MicroPython includes!"
+    raise RuntimeError(msg) from ImportError
 
 # Import the lbutils graphics library
 try:
     import lbutils.graphics as graphics
     import lbutils.graphics.fonts as fonts
 except ImportError:
-    raise RuntimeError(
-        "Error: Missing required LBUtils graphics library",
-    ) from ImportError
+    msg = ("Error: Missing required LBUtils graphics library",)
+    raise RuntimeError(msg) from ImportError
 
 # Import the LB Utils driver for the Pmod OLEDrgb
 try:
     from lbutils.pmods.spi import OLEDrgb
 except ImportError:
-    raise RuntimeError("Error: Cannot find the Pmod OLEDrgb driver!") from ImportError
+    msg = "Error: Cannot find the Pmod OLEDrgb driver!"
+    raise RuntimeError(msg) from ImportError
 
 # Import the core libraries
 import utime

--- a/examples/pmod/pmod_oled_flowers.py
+++ b/examples/pmod/pmod_oled_flowers.py
@@ -38,20 +38,22 @@ try:
     import framebuf
     from machine import SPI, Pin
 except ImportError:
-    raise RuntimeError("Error: Missing required MicroPython includes!")
+    raise RuntimeError("Error: Missing required MicroPython includes!") from ImportError
 
 # Import the lbutils graphics library
 try:
     import lbutils.graphics as graphics
     import lbutils.graphics.fonts as fonts
 except ImportError:
-    raise RuntimeError("Error: Missing required LBUtils graphics library")
+    raise RuntimeError(
+        "Error: Missing required LBUtils graphics library"
+    ) from ImportError
 
 # Import the LB Utils driver for the Pmod OLEDrgb
 try:
     from lbutils.pmods.spi import OLEDrgb
 except ImportError:
-    raise RuntimeError("Error: Cannot find the Pmod OLEDrgb driver!")
+    raise RuntimeError("Error: Cannot find the Pmod OLEDrgb driver!") from ImportError
 
 # Import the core libraries
 import utime

--- a/examples/pmod/pmod_oled_flowers.py
+++ b/examples/pmod/pmod_oled_flowers.py
@@ -43,8 +43,8 @@ except ImportError:
 
 # Import the lbutils graphics library
 try:
-    import lbutils.graphics as graphics
-    import lbutils.graphics.fonts as fonts
+    from lbutils import graphics
+    from lbutils.graphics import fonts
 except ImportError:
     msg = ("Error: Missing required LBUtils graphics library",)
     raise RuntimeError(msg) from ImportError

--- a/lbutils/drivers/__init__.py
+++ b/lbutils/drivers/__init__.py
@@ -45,6 +45,5 @@ This version is written for MicroPython 3.4, and has been tested on:
 
 ### Expose the `drivers` module interface as a full package
 from .common import PIN_ON_SENSE
-
 from .seven_segment import SegDisplay
 from .seven_segment_hex import SegHexDisplay

--- a/lbutils/drivers/seven_segment.py
+++ b/lbutils/drivers/seven_segment.py
@@ -158,9 +158,11 @@ class SegDisplay:
         self.pin_list = []
 
         if (gpio_request is None) or (not gpio_request):
-            raise ValueError("The GPIO Request List is empty")
+            msg = "The GPIO Request List is empty"
+            raise ValueError(msg)
         elif len(gpio_request) != 7:
-            raise ValueError("The GPIO Request List must be EXACTLY seven entries long")
+            msg = "The GPIO Request List must be EXACTLY seven entries long"
+            raise ValueError(msg)
         else:
             for segment in range(7):
                 self.pin_list.append(Pin(gpio_request[segment], Pin.OUT))
@@ -210,6 +212,5 @@ class SegDisplay:
                 for pin in range(7):
                     self.pin_list[pin].value(not self._char_list[character][pin])
         else:
-            raise IndexError(
-                "The display character must be between zero ('0') and nine ('9')",
-            )
+            msg = ("The display character must be between zero ('0') and nine ('9')",)
+            raise IndexError(msg)

--- a/lbutils/drivers/seven_segment.py
+++ b/lbutils/drivers/seven_segment.py
@@ -211,5 +211,5 @@ class SegDisplay:
                     self.pin_list[pin].value(not self._char_list[character][pin])
         else:
             raise IndexError(
-                "The display character must be between zero ('0') and nine ('9')"
+                "The display character must be between zero ('0') and nine ('9')",
             )

--- a/lbutils/drivers/seven_segment.py
+++ b/lbutils/drivers/seven_segment.py
@@ -82,9 +82,9 @@ except ImportError:
 # Import the typing hints if available. Use our backup version
 # if the official library is missing
 try:
-    from typing import Optional, Literal
+    from typing import Literal, Optional
 except ImportError:
-    from lbutils.typing import Optional, Literal  # type: ignore
+    from lbutils.typing import Literal, Optional  # type: ignore
 
 from .common import PIN_ON_SENSE
 

--- a/lbutils/drivers/seven_segment.py
+++ b/lbutils/drivers/seven_segment.py
@@ -76,6 +76,7 @@ This version is written for MicroPython 3.4, and has been tested on:
 # Import MicroPython libraries for GPIO access if available
 try:
     from machine import Pin
+    from micropython import const
 except ImportError:
     print("Ignoring MicroPython includes")
 
@@ -87,6 +88,19 @@ except ImportError:
     from lbutils.typing import Literal, Optional  # type: ignore
 
 from .common import PIN_ON_SENSE
+
+##
+## Constants
+##
+
+DISPLAY_SEGMENTS = const(7)
+"""The number of segements in the display."""
+
+NUM_CHARACTERS = const(9)
+"""The number of individual characters to display.
+
+Each character should have an entry in the internal `_char_list`.
+"""
 
 ##
 ## Classes
@@ -160,7 +174,7 @@ class SegDisplay:
         if (gpio_request is None) or (not gpio_request):
             msg = "The GPIO Request List is empty"
             raise ValueError(msg)
-        elif len(gpio_request) != 7:
+        elif len(gpio_request) != DISPLAY_SEGMENTS:
             msg = "The GPIO Request List must be EXACTLY seven entries long"
             raise ValueError(msg)
         else:
@@ -194,7 +208,7 @@ class SegDisplay:
             The `character` is not in a range that can be displayed.
         """
         # For a character in the valid range...
-        if 0 <= character <= 9:
+        if 0 <= character <= NUM_CHARACTERS:
             if pin_on == "LOW":
                 # ... if the request is to display in the non-inverted form, then
                 # select the row in `_char_list` corresponding to the character to

--- a/lbutils/drivers/seven_segment_hex.py
+++ b/lbutils/drivers/seven_segment_hex.py
@@ -183,9 +183,11 @@ class SegHexDisplay:
         self.pin_list = []
 
         if (gpio_request is None) or (not gpio_request):
-            raise ValueError("The GPIO Request List is empty")
+            msg = "The GPIO Request List is empty"
+            raise ValueError(msg)
         elif len(gpio_request) != 7:
-            raise ValueError("The GPIO Request List must be EXACTLY seven entries long")
+            msg = "The GPIO Request List must be EXACTLY seven entries long"
+            raise ValueError(msg)
         else:
             for segment in range(7):
                 self.pin_list.append(Pin(gpio_request[segment], Pin.OUT))
@@ -249,9 +251,10 @@ class SegHexDisplay:
                     for pin in range(7):
                         self.pin_list[pin].value(not self._char_list[character][pin])
             else:
-                raise IndexError(
+                msg = (
                     "The display character must be between zero ('0') and sixteen ('F')",
                 )
+                raise IndexError(msg)
 
         # Convert a string integer in the range [0..F], and then display
         elif isinstance(character, str):
@@ -284,13 +287,13 @@ class SegHexDisplay:
                             not self._char_list[_char_list_index][pin],
                         )
             else:
-                raise IndexError(
-                    "The display character must be a string between '0' and 'F'",
-                )
+                msg = ("The display character must be a string between '0' and 'F'",)
+                raise IndexError(msg)
 
         # If we can't convert the input `character`, raise an exception
         else:
-            raise TypeError(
+            msg = (
                 "The 'character' parameter must either be an integer ('int') or a"
                 " string ('str') type.",
             )
+            raise TypeError(msg)

--- a/lbutils/drivers/seven_segment_hex.py
+++ b/lbutils/drivers/seven_segment_hex.py
@@ -250,7 +250,7 @@ class SegHexDisplay:
                         self.pin_list[pin].value(not self._char_list[character][pin])
             else:
                 raise IndexError(
-                    "The display character must be between zero ('0') and sixteen ('F')"
+                    "The display character must be between zero ('0') and sixteen ('F')",
                 )
 
         # Convert a string integer in the range [0..F], and then display
@@ -281,16 +281,16 @@ class SegHexDisplay:
                     # the column value in `_char_list` for that segment value
                     for pin in range(7):
                         self.pin_list[pin].value(
-                            not self._char_list[_char_list_index][pin]
+                            not self._char_list[_char_list_index][pin],
                         )
             else:
                 raise IndexError(
-                    "The display character must be a string between '0' and 'F'"
+                    "The display character must be a string between '0' and 'F'",
                 )
 
         # If we can't convert the input `character`, raise an exception
         else:
             raise TypeError(
                 "The 'character' parameter must either be an integer ('int') or a"
-                " string ('str') type."
+                " string ('str') type.",
             )

--- a/lbutils/drivers/seven_segment_hex.py
+++ b/lbutils/drivers/seven_segment_hex.py
@@ -71,9 +71,10 @@ This version is written for MicroPython 3.4, and has been tested on:
 * Raspberry Pi Pico H/W
 """
 
-# Import MicroPython libraries for GPIO access if available
+# Import MicroPython libraries for GPIO access and constants if available
 try:
     from machine import Pin
+    from micropython import const
 except ImportError:
     print("Ignoring MicroPython includes")
 
@@ -106,6 +107,15 @@ those which don't fit into `ASCII_DIGITS`"""
 ASCII_HEX_EXTRA_DIGITS = set("ABCDEF")
 """Constant for the set of ASCII hexadecimal decimal digits, including _only_
 those which don't fit into `ASCII_DIGITS`"""
+
+DISPLAY_SEGMENTS = const(7)
+"""The number of segements in the display."""
+
+NUM_CHARACTERS = const(9)
+"""The number of individual characters to display.
+
+Each character should have an entry in the internal `_char_list`.
+"""
 
 ##
 ## Classes
@@ -185,7 +195,7 @@ class SegHexDisplay:
         if (gpio_request is None) or (not gpio_request):
             msg = "The GPIO Request List is empty"
             raise ValueError(msg)
-        elif len(gpio_request) != 7:
+        elif len(gpio_request) != DISPLAY_SEGMENTS:
             msg = "The GPIO Request List must be EXACTLY seven entries long"
             raise ValueError(msg)
         else:
@@ -233,7 +243,7 @@ class SegHexDisplay:
         # Convert a decimal integer in the range [0..15], and then display
         if isinstance(character, int):
             # For a character in the valid range...
-            if 0 <= character <= 15:
+            if 0 <= character <= NUM_CHARACTERS:
                 if pin_on == "LOW":
                     # ... if the request is to display in the non-inverted form, then
                     # select the row in `_char_list` corresponding to the character to

--- a/lbutils/drivers/seven_segment_hex.py
+++ b/lbutils/drivers/seven_segment_hex.py
@@ -86,9 +86,9 @@ except ImportError:
 # Import the typing hints if available. Use our backup version
 # if the official library is missing
 try:
-    from typing import Optional, Literal
+    from typing import Literal, Optional
 except ImportError:
-    from lbutils.typing import Optional, Literal  # type: ignore
+    from lbutils.typing import Literal, Optional  # type: ignore
 
 from .common import PIN_ON_SENSE
 

--- a/lbutils/graphics/__init__.py
+++ b/lbutils/graphics/__init__.py
@@ -113,6 +113,6 @@ documentation for the sub-class itself.
 ### Expose the `graphics` module interface as a full package
 __all__ = ["colours", "canvas", "helpers"]
 
-from .colours import DEVICE_BIT_ORDER, Colour
 from .canvas import RECTANGLE_STYLE, Canvas, FrameBufferCanvas
-from .helpers import Pen, Pixel, BoundPixel
+from .colours import DEVICE_BIT_ORDER, Colour
+from .helpers import BoundPixel, Pen, Pixel

--- a/lbutils/graphics/canvas.py
+++ b/lbutils/graphics/canvas.py
@@ -132,8 +132,8 @@ class Canvas(ABC):
     primitives that can be relied upon by higher-level libraries.
     * **Font Support**: The `Canvas` maintains a record of the current font to
     use when writing text through the `font` attribute. This can be changed by
-    users of the library, and defaults to [`Org_01`]
-    [lbutils.graphics.fonts.Org_01].
+    users of the library, and defaults to [`Org01`]
+    [lbutils.graphics.fonts.Org01].
     * **Colour Support**: Colours can be selected in different ways, and the
     `Canvas` maintains a foreground (`fg_colour`) and background (`bg_colour`)
     attribute: along with a common method to override these default colours
@@ -153,29 +153,29 @@ class Canvas(ABC):
     Attributes
     ----------
 
-    bg_colour:
+    bg_colour: graphics.Colour
          The background [`Colour`][lbutils.graphics.colours.Colour] to use when
          drawing.
-    cursor:
+    cursor: graphics.BoundPixel
          The [`x`][lbutils.graphics.BoundPixel] and [`y`]
          [lbutils.graphics.BoundPixel] locations  of the current write
          (or read) operation.
-    origin:
+    origin: graphics.BoundPixel
          The _user_ reference point for the next sequence of drawing primitives.
          This `origin` will not be altered by changes to the [`x`]
          [lbutils.graphics.BoundPixel] and [`y`]
          [lbutils.graphics.BoundPixel] locations of any drawing command.
-    font:
+    font: fonts.BaseFont
          The sub-class of [`BaseFont`][lbutils.graphics.fonts.base_font.BaseFont]
          to use when drawing characters.
-    fg_colour:
+    fg_colour: graphics.Colour
          The foreground [`Colour`][lbutils.graphics.colours.Colour] to use when
          drawing.
-    pen:
+    pen: graphics.Pen
          The [`Pen`][lbutils.graphics.Pen] to use when drawing on the canvas.
-    height:
+    height: int
          A read-only value for the height of the canvas in pixels.
-    width:
+    width: int
          A read-only value for the width of the canvas in pixels.
     x: int
             The X co-ordinate value of the `cursor`
@@ -185,7 +185,7 @@ class Canvas(ABC):
             A tuple representing the co-ordinate (x ,y) of the `cursor`
 
     Methods
-    ----------
+    -------
 
     **Cursor and Origin Movements**
 
@@ -271,6 +271,18 @@ class Canvas(ABC):
     _font: fonts.BaseFont
 
     ##
+    ## Public Attributes
+    ##
+
+    bg_colour: graphics.Colour
+    fg_colour: graphics.Colour
+
+    pen: Optional[graphics.Pen]
+
+    width: int
+    height: int
+
+    ##
     ## Constructors
     ##
 
@@ -280,8 +292,7 @@ class Canvas(ABC):
         height: int,
         bit_order: Optional[Literal["ARM", "INTEL"]] = "ARM",
     ) -> None:
-        """Creates a (packed) representation of a colour value, from the three
-        bytes `r` (red), `g` (green) and `b` (blue).
+        """Create the drawing `Canvas` with the specified `width` and `height`.
 
         Parameters
         ----------
@@ -309,7 +320,7 @@ class Canvas(ABC):
             0, 0, min_x=0, max_x=width, min_y=0, max_y=height
         )
 
-        self._font = fonts.Org_01()
+        self._font = fonts.Org01()
 
         self.width = width
         self.height = height
@@ -869,8 +880,9 @@ class Canvas(ABC):
     ##
 
     def move_to(self, xy: tuple[int, int]) -> None:
-        """Sets the internal `x` and `y` co-ordinates of the `cursor` as a
-        tuple. An alias for the `x_y` property of `Canvas`.
+        """Set the internal (`x`, `y`) co-ordinates of the `cursor` to the
+        values of the `xy` two-value tuple. An alias for the `x_y` property of
+        `Canvas`.
 
         Parameters
         ----------
@@ -890,7 +902,7 @@ class Canvas(ABC):
         self.cursor.x_y = xy
 
     def move_origin_to(self) -> None:
-        """Sets the user drawing [`origin`] [lbutils.graphics.Canvas.origin] of
+        """Set the user drawing [`origin`] [lbutils.graphics.Canvas.origin] of
         the `Canvas` to the specified co-ordinate the next sequence of drawing
         commands.
 

--- a/lbutils/graphics/canvas.py
+++ b/lbutils/graphics/canvas.py
@@ -97,7 +97,9 @@ try:
     import lbutils.graphics as graphics
     import lbutils.graphics.fonts as fonts
 except ImportError:
-    raise RuntimeError("Error: Missing required LBUtils graphics library")
+    raise RuntimeError(
+        "Error: Missing required LBUtils graphics library"
+    ) from ImportError
 
 ###
 ### Enumerations. MicroPython doesn't have actual an actual `enum` (yet), so

--- a/lbutils/graphics/canvas.py
+++ b/lbutils/graphics/canvas.py
@@ -57,7 +57,8 @@ class and the underlying display protocols.
 The simplest derived class
 
 ````python
-import lbutils.graphics as graphics
+from lbutils import graphics
+from lbutils.graphics import colours, fonts
 
 display = graphics.FrameBufferCanvas(width: int = 96,
         height: int = 64)
@@ -71,7 +72,7 @@ For insance the
 can be cleared to black by
 
 ````python
-display.fill_screen(graphics.colours.COLOUR_BLACK)
+display.fill_screen(colours.COLOUR_BLACK)
 ````
 
 ## Tested Implementations
@@ -95,7 +96,7 @@ except ImportError:
 # Import the lbutils graphics library
 try:
     from lbutils import graphics
-    from lbutils.graphics import fonts
+    from lbutils.graphics import colours, fonts
 except ImportError:
     msg = ("Error: Missing required LBUtils graphics library",)
     raise RuntimeError(msg) from ImportError
@@ -309,8 +310,8 @@ class Canvas(ABC):
         """
         # Set the Attribute Values. Note use the properties to ensure
         # that the type being set is correctly
-        self.fg_colour = graphics.colours.Colour(255, 255, 255, bit_order)
-        self.bg_colour = graphics.colours.Colour(0, 0, 0, bit_order)
+        self.fg_colour = colours.Colour(255, 255, 255, bit_order)
+        self.bg_colour = colours.Colour(0, 0, 0, bit_order)
 
         self.pen = None
 
@@ -665,7 +666,7 @@ class Canvas(ABC):
         elif self.fg_colour is not None:
             return self.fg_colour
         else:
-            return graphics.colours.COLOUR_WHITE
+            return colours.COLOUR_WHITE
 
     def select_bg_colour(
         self,
@@ -720,7 +721,7 @@ class Canvas(ABC):
         elif self.bg_colour is not None:
             return self.bg_colour
         else:
-            return graphics.colours.COLOUR_BLACK
+            return colours.COLOUR_BLACK
 
     ##
     ## Drawing Primitives using the `cursor`

--- a/lbutils/graphics/canvas.py
+++ b/lbutils/graphics/canvas.py
@@ -94,8 +94,8 @@ except ImportError:
 
 # Import the lbutils graphics library
 try:
-    import lbutils.graphics as graphics
-    import lbutils.graphics.fonts as fonts
+    from lbutils import graphics
+    from lbutils.graphics import fonts
 except ImportError:
     msg = ("Error: Missing required LBUtils graphics library",)
     raise RuntimeError(msg) from ImportError

--- a/lbutils/graphics/canvas.py
+++ b/lbutils/graphics/canvas.py
@@ -98,7 +98,7 @@ try:
     import lbutils.graphics.fonts as fonts
 except ImportError:
     raise RuntimeError(
-        "Error: Missing required LBUtils graphics library"
+        "Error: Missing required LBUtils graphics library",
     ) from ImportError
 
 ###
@@ -316,10 +316,20 @@ class Canvas(ABC):
         self.pen = None
 
         self.cursor = graphics.BoundPixel(
-            0, 0, min_x=0, max_x=width, min_y=0, max_y=height
+            0,
+            0,
+            min_x=0,
+            max_x=width,
+            min_y=0,
+            max_y=height,
         )
         self.origin = graphics.BoundPixel(
-            0, 0, min_x=0, max_x=width, min_y=0, max_y=height
+            0,
+            0,
+            min_x=0,
+            max_x=width,
+            min_y=0,
+            max_y=height,
         )
 
         self._font = fonts.Org01()

--- a/lbutils/graphics/canvas.py
+++ b/lbutils/graphics/canvas.py
@@ -393,7 +393,7 @@ class Canvas(ABC):
         return self._cursor
 
     @cursor.setter
-    def cursor(self, value) -> None:
+    def cursor(self, value: graphics.BoundPixel) -> None:
         self._cursor = value
 
     @property
@@ -408,7 +408,7 @@ class Canvas(ABC):
         return self._origin
 
     @origin.setter
-    def origin(self, value) -> None:
+    def origin(self, value: graphics.BoundPixel) -> None:
         self._origin = value
 
     ##
@@ -604,7 +604,7 @@ class Canvas(ABC):
         self,
         fg_colour: Optional[graphics.Colour] = None,
         pen: Optional[graphics.Pen] = None,
-    ):
+    ) -> graphics.Colour:
         """Return the colour to be used for drawing in the foreground, taking
         into account the (optional) overrides specified in `color` and `pen`.
         The selected colour will obey the standard colour selection precedence
@@ -646,7 +646,7 @@ class Canvas(ABC):
         """
 
         if pen is not None:
-            return fg_colour
+            return pen.fg_colour
         elif fg_colour is not None:
             return fg_colour
         elif self.pen is not None:
@@ -660,7 +660,7 @@ class Canvas(ABC):
         self,
         bg_colour: Optional[graphics.Colour] = None,
         pen: Optional[graphics.Pen] = None,
-    ):
+    ) -> graphics.Colour:
         """Return the colour to be used for drawing in the background, taking
         into account the (optional) overrides specified in `bg_colour` and
         `pen`. The selected colour will obey the standard colour selection
@@ -701,7 +701,7 @@ class Canvas(ABC):
         """
 
         if pen is not None:
-            return bg_colour
+            return pen.bg_colour
         elif bg_colour is not None:
             return bg_colour
         elif self.pen is not None:

--- a/lbutils/graphics/canvas.py
+++ b/lbutils/graphics/canvas.py
@@ -97,9 +97,8 @@ try:
     import lbutils.graphics as graphics
     import lbutils.graphics.fonts as fonts
 except ImportError:
-    raise RuntimeError(
-        "Error: Missing required LBUtils graphics library",
-    ) from ImportError
+    msg = ("Error: Missing required LBUtils graphics library",)
+    raise RuntimeError(msg) from ImportError
 
 ###
 ### Enumerations. MicroPython doesn't have actual an actual `enum` (yet), so

--- a/lbutils/graphics/colours.py
+++ b/lbutils/graphics/colours.py
@@ -105,11 +105,11 @@ class Colour:
 
     Attributes
     ----------
-    bR: int, read-only
+    red: int, read-only
         The byte (`0..255`) of the red component of the colour
-    bG: int, read-only
+    green: int, read-only
         The byte (`0..255`) of the green component of the colour
-    bB: int, read-only
+    blue: int, read-only
         The byte (`0..255`) of the blue component of the colour
     as_565: int, read-only
         Provides the colour value in the RGB565 format, using a single
@@ -147,9 +147,9 @@ class Colour:
     _565: Optional[int]
     _888: Optional[int]
 
-    _bR: Optional[int]
-    _bG: Optional[int]
-    _bB: Optional[int]
+    _red: Optional[int]
+    _green: Optional[int]
+    _blue: Optional[int]
 
     ##
     ## Constructors
@@ -162,11 +162,11 @@ class Colour:
         b: int,
         bit_order: Optional[Literal["ARM", "INTEL"]] = "ARM",
     ) -> None:
-        """Creates a representation of a colour value, from the three integers
+        """Create a representation of a colour value, from the three integers
         `r` (red), `g` (green) and `b` (blue). The class will accept anything
-        which can be coerced to an integer as arguments: the access through the
-        attributes will determine the representation used when displaying the
-        colour.
+        which can be coerced to an integer as arguments: the methods used to
+        access the colour (and the `bit_order`) will determine the byte order
+        used as the final representation used when displaying the colour.
 
         Parameters
         ----------
@@ -200,37 +200,37 @@ class Colour:
         self._565 = None
         self._888 = None
 
-        self._bR = None
-        self._bG = None
-        self._bB = None
+        self._red = None
+        self._green = None
+        self._blue = None
 
     ##
     ## Properties
     ##
 
     @property
-    def bR(self) -> int:
+    def red(self) -> int:
         """The red component of the colour value, packed to a single byte."""
-        if self._bR is None:
-            self._bR = self._r & 0xFF
+        if self._red is None:
+            self._red = self._r & 0xFF
 
-        return self._bR
+        return self._red
 
     @property
-    def bG(self) -> int:
+    def green(self) -> int:
         """The green component of the colour value, packed to a single byte."""
-        if self._bG is None:
-            self._bG = self._g & 0xFF
+        if self._green is None:
+            self._green = self._g & 0xFF
 
-        return self._bG
+        return self._green
 
     @property
-    def bB(self) -> int:
+    def blue(self) -> int:
         """The blue component of the colour value, packed to a single byte."""
-        if self._bB is None:
-            self._bB = self._b & 0xFF
+        if self._blue is None:
+            self._blue = self._b & 0xFF
 
-        return self._bB
+        return self._blue
 
     @property
     def as_565(self) -> Optional[int]:
@@ -238,7 +238,7 @@ class Colour:
         Construct a packed word from the internal colour representation, with
         5 bits of red data, 6 of green, and 5 of blue. On ARM platforms
         the packed word representation has the high and low bytes swapped,
-        and so looks like
+        and so looks like.
 
         ````
         F  E  D  C  B  A  9  8  7  6  5  4  3  2  1  0
@@ -283,7 +283,7 @@ class Colour:
         Construct a packed double word from the internal colour representation,
         with 8 bits of red data, 8 bits of green, and 8 of blue. For non-ARM
         platforms this results in a byte order for the two colour words as
-        follows
+        follows.
 
         ````
         F  E  D  C  B  A  9  8  7  6  5  4  3  2  1  0

--- a/lbutils/graphics/colours.py
+++ b/lbutils/graphics/colours.py
@@ -198,11 +198,14 @@ class Colour:
 
         # Attempt to determine the platform automatically:
         # defaulting to the ARM bit order
-        machine = uname()
-        if machine[4].find("x86") != -1:
-            self.bit_order = "INTEL"
+        if bit_order is None:
+            machine = uname()
+            if machine[4].find("x86") != -1:
+                self.bit_order = "INTEL"
+            else:
+                self.bit_order = "ARM"
         else:
-            self.bit_order = "ARM"
+            self.bit_order = bit_order
 
         # Cached values
         self._565 = None
@@ -339,9 +342,9 @@ class Colour:
         """Create a [`Colour`][lbutils.graphics.Colour] object from the byte
         passed in as a parameter: assuming the byte is an RGB 565 packed
         byte."""
-        red = 0
-        green = 0
-        blue = 0
+        red = rgb & 0xF800
+        green = rgb & 0x07E0
+        blue = rgb & 0x001F
 
         new_colour = Colour(red, green, blue)
 

--- a/lbutils/graphics/colours.py
+++ b/lbutils/graphics/colours.py
@@ -76,9 +76,9 @@ shown below
 # Import the typing hints if available. Use our backup version
 # if the official library is missing
 try:
-    from typing import Optional, Literal
+    from typing import Literal, Optional
 except ImportError:
-    from lbutils.typing import Optional, Literal  # type: ignore
+    from lbutils.typing import Literal, Optional  # type: ignore
 
 from os import uname
 

--- a/lbutils/graphics/colours.py
+++ b/lbutils/graphics/colours.py
@@ -121,7 +121,15 @@ class Colour:
     bit_order: DEVICE_BIT_ORDER, read-write
         Argument indicating if the underlying bit order used for
         the bit packing order in colour conversions. Defaults to
-        `ARM` as set by the default constructor.
+        auto-detect the bit order in the default constructor.
+
+    Methods
+    -------
+
+    from_565: Color
+        Create a [`Colour`][lbutils.graphics.Colour] object from the byte
+        passed in as a parameter: assuming the byte is an RGB 565 packed
+        byte.
 
     Implementation
     --------------
@@ -321,6 +329,23 @@ class Colour:
 
         # Return the calculated value to the client
         return self._888
+
+    ##
+    ## Methods
+    ##
+
+    @staticmethod
+    def from_565(rgb: int) -> Colour:
+        """Create a [`Colour`][lbutils.graphics.Colour] object from the byte
+        passed in as a parameter: assuming the byte is an RGB 565 packed
+        byte."""
+        red = 0
+        green = 0
+        blue = 0
+
+        new_colour = Colour(red, green, blue)
+
+        return new_colour
 
 
 ###

--- a/lbutils/graphics/fonts/__init__.py
+++ b/lbutils/graphics/fonts/__init__.py
@@ -58,7 +58,6 @@ Python file.
 
 ### Expose the `fonts` module interface as a full package
 from .base_font import BaseFont
-
 from .font06 import Font_06
 from .font08 import Font_08
 from .org_01 import Org_01

--- a/lbutils/graphics/fonts/__init__.py
+++ b/lbutils/graphics/fonts/__init__.py
@@ -31,9 +31,9 @@ described below. This reconstruction is undertaken by the [`BaseFont`]
 be sub-classed for a specific font. Currently the fonts (and subclasses) exposed
 in this library are
 
-  * [`Font06`][lbutils.graphics.fonts.font06.Font_06]. 6x6 pixel sans-serif font.
-  * [`Font08`][lbutils.graphics.fonts.font08.Font_08]. 8x8 pixel sans-serif font.
-  * [`Org_01`][lbutils.graphics.fonts.org_01.Org_01]. A tiny, stylized font with
+  * [`Font06`][lbutils.graphics.fonts.font06.Font06]. 6x6 pixel sans-serif font.
+  * [`Font08`][lbutils.graphics.fonts.font08.Font08]. 8x8 pixel sans-serif font.
+  * [`Org01`][lbutils.graphics.fonts.org_01.Org01]. A tiny, stylized font with
   all characters within a 6 pixel height. Created by fontconvert, from the Org_v01
   by Orgdot.
 
@@ -58,6 +58,6 @@ Python file.
 
 ### Expose the `fonts` module interface as a full package
 from .base_font import BaseFont
-from .font06 import Font_06
-from .font08 import Font_08
-from .org_01 import Org_01
+from .font06 import Font06
+from .font08 import Font08
+from .org_01 import Org01

--- a/lbutils/graphics/fonts/base_font.py
+++ b/lbutils/graphics/fonts/base_font.py
@@ -79,13 +79,6 @@ Adafruit_GFX.cpp) for a more detailed explanation of how the glyphs are
 reconstructed from the font data.
 """
 
-# Import the typing hints if available. Use our backup version
-# if the offical library is missing
-try:
-    from typing import Dict
-except ImportError:
-    from lbutils.typing import Dict  # type: ignore
-
 
 class BaseFont:
     """A Base Class which implements the access methods required to use the
@@ -94,7 +87,7 @@ class BaseFont:
     that bitmap is handled here by `BaseFont`.
 
     Methods
-    ----------
+    -------
 
     * `get_bit()`. Returns the state ('0' or '1') of the bit specified by
     the current cursor `position` within the current glyph bitmap.
@@ -107,7 +100,7 @@ class BaseFont:
     in the next natural position.
     """
 
-    def __init__(self, bitmap: bytes, index: Dict[str, int], glyph: list) -> None:
+    def __init__(self, bitmap: bytes, index: dict[str, int], glyph: list) -> None:
         """Take the byte array of `bitmap`s with the `index` of font characters
         and use these together with the `glyph` list to reconstruct the required
         font. This method is typically called by a sub-class in the constructor
@@ -178,7 +171,7 @@ class BaseFont:
         self.position = self.current_glyph[0] * 8
 
     def get_bit(self, position: int) -> int:
-        """Returns the state ('0' or '1') of the bit specified by the current
+        """Return the state ('0' or '1') of the bit specified by the current
         cursor `position` within the current glyph bitmap.
 
         Parameters

--- a/lbutils/graphics/fonts/font06.py
+++ b/lbutils/graphics/fonts/font06.py
@@ -216,7 +216,7 @@ class Font06(BaseFont):
             0x80,
             0x3E,
             0x00,
-        ]
+        ],
     )
 
     index = {

--- a/lbutils/graphics/fonts/font06.py
+++ b/lbutils/graphics/fonts/font06.py
@@ -23,7 +23,7 @@
 from .base_font import BaseFont
 
 
-class Font_06(BaseFont):
+class Font06(BaseFont):
     """6x6 pixel sans-serif font, created by
     [`fontconvert`](https://github.com/danjperron/ssd1331_micropython.git)."""
 

--- a/lbutils/graphics/fonts/font08.py
+++ b/lbutils/graphics/fonts/font08.py
@@ -367,7 +367,7 @@ class Font08(BaseFont):
             0x00,
             0x1F,
             0x80,
-        ]
+        ],
     )
 
     index = {

--- a/lbutils/graphics/fonts/font08.py
+++ b/lbutils/graphics/fonts/font08.py
@@ -23,7 +23,7 @@
 from .base_font import BaseFont
 
 
-class Font_08(BaseFont):
+class Font08(BaseFont):
     """8x8 pixel sans-serif font, created by
     [`fontconvert`](https://github.com/danjperron/ssd1331_micropython.git)."""
 

--- a/lbutils/graphics/fonts/org_01.py
+++ b/lbutils/graphics/fonts/org_01.py
@@ -307,7 +307,7 @@ class Org01(BaseFont):
             0xA8,
             0x0F,
             0xE0,
-        ]
+        ],
     )
 
     index = {

--- a/lbutils/graphics/fonts/org_01.py
+++ b/lbutils/graphics/fonts/org_01.py
@@ -23,7 +23,7 @@
 from .base_font import BaseFont
 
 
-class Org_01(BaseFont):
+class Org01(BaseFont):
     """A tiny, stylized font with all characters within a 6 pixel height.
 
     Created by [`fontconvert`](https://github.com/danjperron/

--- a/lbutils/graphics/helpers.py
+++ b/lbutils/graphics/helpers.py
@@ -31,13 +31,6 @@ separate library.
 *   CPython (3.10)
 """
 
-# Import the typing hints if available. Use our backup version
-# if the offical library is missing
-try:
-    from typing import Type
-except ImportError:
-    from lbutils.typing import Type  # type: ignore
-
 # Import the math library (needed for polar co-ordinates)
 from math import cos, sin
 
@@ -65,21 +58,21 @@ class Pen:
 
     ````python
     normal_text = Pen(COLOUR_WHITE)
-    alter_text = Pen(COLOUR_RED)
+    alert_text = Pen(COLOUR_RED)
     ````
 
     This defines a `normal_text` pen with a white foreground and default
     background and line thickness (black and 1 pixel byt default). A second pen
-    for `alter_text` has a red foreground, and similarly a black background with
+    for `alert_text` has a red foreground, and similarly a black background with
     1 pixel thickness. Text can then be written on the canvas using these two
     pens on a `Canvas` as
 
     ````python
     canvas = Canvas(width = 96, height = 48)
 
-    canvas.write_text(0, 10, "This is normal text", pen = normal_text)
-    canvas.write_text(0, 20, "and this is alert", pen = altert_text)
-    canvas.write_text(0, 30, "Now everything is back to normal", pen = normal_text)
+    canvas.write_text(start= (0, 10), "This is normal text", pen = normal_text)
+    canvas.write_text(start= (0, 20), "and this is alert", pen = alert_text)
+    canvas.write_text(start= (0, 30), "Now everything is back to normal", pen = normal_text)
     ````
 
     Attributes
@@ -99,7 +92,7 @@ class Pen:
         bg_colour: Colour = COLOUR_BLACK,
         thickness: int = 1,
     ) -> None:
-        """Creates a `Pen` instance, using the specified foreground and
+        """Create a `Pen` instance, using the specified foreground and
         background colour, and line thickness."""
 
         self.bg_colour = bg_colour
@@ -136,7 +129,7 @@ class Pixel:
             A tuple representing the co-ordinate (x ,y).
 
     Methods
-    ----------
+    -------
 
     * `move_to()`. Move the internal co-ordinate to the value (x, y). An alias
     for the [`x_y`][lbutils.graphics.Pixel.x_y] property.
@@ -158,7 +151,7 @@ class Pixel:
     ##
 
     def __init__(self, x: int, y: int) -> None:
-        """Creates a `Pixel` instance holding the specified `x` and `y` co-
+        """Create a `Pixel` instance holding the specified `x` and `y` co-
         ordinates, together representing the Cartesian point '(`x`, `y`)'.
 
         Parameters
@@ -229,7 +222,7 @@ class Pixel:
     ##
 
     def move_to(self, xy: tuple[int, int]) -> None:
-        """Sets the internal `x` and `y` co-ordinates as a tuple. An alias for
+        """Set the internal `x` and `y` co-ordinates as a tuple. An alias for
         the `x_y` property.
 
         Parameters
@@ -250,7 +243,7 @@ class Pixel:
         self.x_y = xy
 
     def offset(self, x: int = 0, y: int = 0) -> tuple[int, int]:
-        """Returns a `tuple` representing the (x, y) co-ordinate of the current
+        """Return a `tuple` representing the (x, y) co-ordinate of the current
         `Pixel` with the specified Cartesian off-set applied.
 
         Example
@@ -296,7 +289,7 @@ class Pixel:
         return (self.x + x, self.y + y)
 
     def offset_polar(self, r: int = 0, theta: int = 0) -> tuple[int, int]:
-        """Returns a `tuple` representing the (x, y) co-ordinate of the current
+        """Return a `tuple` representing the (x, y) co-ordinate of the current
         `Pixel` with the specified Polar off-set applied as the radius `r` and
         angle `theta`.
 
@@ -407,7 +400,7 @@ class BoundPixel(Pixel):
         min_x: int = 0,
         min_y: int = 0,
     ) -> None:
-        """Creates a `Pixel` instance holding the specified `x` and `y` co-
+        """Create a `Pixel` instance holding the specified `x` and `y` co-
         ordinates, together representing the Cartesian point '(`x`, `y`)'. This
         `x` and `y` value is guaranteed to be maintained between `min_x` and
         `max_x` for the `x` co- ordinate, and `min_y` and `max_y` for the `y`

--- a/lbutils/graphics/helpers.py
+++ b/lbutils/graphics/helpers.py
@@ -41,7 +41,7 @@ except ImportError:
 # Import the math library (needed for polar co-ordinates)
 from math import cos, sin
 
-from .colours import COLOUR_WHITE, COLOUR_BLACK, Colour
+from .colours import COLOUR_BLACK, COLOUR_WHITE, Colour
 
 ###
 ### Classes

--- a/lbutils/helpers/i2c.py
+++ b/lbutils/helpers/i2c.py
@@ -29,7 +29,7 @@ MicroPython library `machine.I2C`, and the classes for the I2C 'pmods' in
 with the defaults for the Leeds Beckett micro-controller development board.
 """
 
-from machine import Pin, I2C
+from machine import I2C, Pin
 
 I2C_SDA_PIN_DEFAULT = 16
 """Define the pin used for the I2C data line, SDA, when scanning for I2C

--- a/lbutils/pmods/spi/__init__.py
+++ b/lbutils/pmods/spi/__init__.py
@@ -35,7 +35,7 @@ supported: this module also only supports those with a dedicated SPI interface.
 
 ![Modern Naming Conventions for the SPI Interfaces](docs/media/spi_interfaces.png)
 
-**Figure 1: Modern Naming Conventions for the SPI Interfaces [CC0 – Public Domain]**
+**Figure 1: Modern Naming Conventions for the SPI Interfaces [CC0 - Public Domain]**
 
 In general each module will require a minimum of four pins for the SPI
 interface, as shown in Figure 1. For the SPI modes in the [PMod Interface

--- a/lbutils/pmods/spi/oledrgb.py
+++ b/lbutils/pmods/spi/oledrgb.py
@@ -640,7 +640,7 @@ class OLEDrgb(graphics.Canvas):
                     use_fg_colour.green,
                     use_fg_colour.blue,
                 )
-        except Exception:
+        except ustruct.error:
             raise ValueError(
                 "Invalid parameters has been passed to 'draw_line'. I cannot"
                 "interpret the co-ordinates passed as arguments: check the"

--- a/lbutils/pmods/spi/oledrgb.py
+++ b/lbutils/pmods/spi/oledrgb.py
@@ -80,7 +80,9 @@ except ImportError:
 try:
     import lbutils.graphics as graphics
 except ImportError:
-    raise RuntimeError("Error: Missing required LBUtils graphics library")
+    raise RuntimeError(
+        "Error: Missing required LBUtils graphics library"
+    ) from ImportError
 
 # Import the core libraries
 import ustruct
@@ -645,7 +647,7 @@ class OLEDrgb(graphics.Canvas):
                 "Invalid parameters has been passed to 'draw_line'. I cannot"
                 "interpret the co-ordinates passed as arguments: check the"
                 "'start' and 'end' tuples are correct"
-            )
+            ) from ustruct.error
 
         self._write(_DRAWLINE, data)
 

--- a/lbutils/pmods/spi/oledrgb.py
+++ b/lbutils/pmods/spi/oledrgb.py
@@ -86,11 +86,11 @@ except ImportError:
 import ustruct
 import utime
 
-# Allow the use of MicroPython constants
-from micropython import const
-
 # Reference the MicroPython Pin library
 from machine import Pin
+
+# Allow the use of MicroPython constants
+from micropython import const
 
 ##
 ## Display Commands. Internal list of the command code required by the SSD1331

--- a/lbutils/pmods/spi/oledrgb.py
+++ b/lbutils/pmods/spi/oledrgb.py
@@ -23,7 +23,7 @@ OLEDrgb](https://digilent.com/reference/pmod/pmodoledrgb/start), based on the
 ['ssd1331'](https://github.com/danjperron/pico_mpu6050_ssd1331) driver by Daniel
 Perron. The [Pmod
 OLEDrgb](https://digilent.com/reference/pmod/pmodoledrgb/start) provides an OLED
-screen with a 96×64 pixel display capable of 16-bit RGB colour resolution.
+screen with a 96x64 pixel display capable of 16-bit RGB colour resolution.
 
 !!! note
 

--- a/lbutils/pmods/spi/oledrgb.py
+++ b/lbutils/pmods/spi/oledrgb.py
@@ -70,7 +70,7 @@ header below.
 """
 
 # Import the typing hints if available. Use our backup version
-# if the offical library is missing
+# if the official library is missing
 try:
     from typing import Literal, Optional, Union
 except ImportError:
@@ -147,8 +147,8 @@ class OLEDrgb(graphics.Canvas):
     primitives that can be relied upon by higher-level libraries.
     * **Font Support**: The `Canvas` maintains a record of the current font to
     use when writing text through the `font` attribute. This can be changed by
-    users of the library, and defaults to [`Org_01`]
-    [lbutils.graphics.fonts.Org_01].
+    users of the library, and defaults to [`Org01`]
+    [lbutils.graphics.fonts.Org01].
     * **Colour Support**: Colours can be selected in different ways, and the
     `Canvas` maintains a foreground (`fg_colour`) and background (`bg_color`)
     attribute: along with a common method to override these default colours
@@ -168,30 +168,30 @@ class OLEDrgb(graphics.Canvas):
     Attributes
     ----------
 
-    bg_colour:
-         The background [`Colour`][lbutils.graphics.colours.Colour] to use when
-         drawing.
-    cursor:
-         The [`x`][lbutils.graphics.BoundPixel] and [`y`]
-         [lbutils.graphics.BoundPixel] locations  of the current write
-         (or read) operation.
-    origin:
-         The _user_ reference point for the next sequence of drawing primitives.
-         This `origin` will not be altered by changes to the [`x`]
-         [lbutils.graphics.BoundPixel] and [`y`]
-         [lbutils.graphics.BoundPixel] locations of any drawing command.
-    font:
-         The sub-class of [`BaseFont`][lbutils.graphics.fonts.base_font.BaseFont]
-         to use when drawing characters.
-    fg_colour:
-         The foreground [`Colour`][lbutils.graphics.colours.Colour] to use when
-         drawing.
-    pen:
-         The [`Pen`][lbutils.graphics.Pen] to use when drawing on the canvas.
-    height:
-         A read-only value for the height of the canvas in pixels.
-    width:
-         A read-only value for the width of the canvas in pixels.
+    bg_colour: graphics.Colour
+        The background [`Colour`][lbutils.graphics.colours.Colour] to use when
+        drawing.
+    cursor: graphics.BoundPixel
+        The [`x`][lbutils.graphics.BoundPixel] and [`y`]
+        [lbutils.graphics.BoundPixel] locations  of the current write
+        (or read) operation.
+    origin: graphics.BoundPixel
+        The _user_ reference point for the next sequence of drawing primitives.
+        This `origin` will not be altered by changes to the [`x`]
+        [lbutils.graphics.BoundPixel] and [`y`]
+        [lbutils.graphics.BoundPixel] locations of any drawing command.
+    font: fonts.BaseFont
+        The sub-class of [`BaseFont`][lbutils.graphics.fonts.base_font.BaseFont]
+        to use when drawing characters.
+    fg_colour: graphics.Colour
+        The foreground [`Colour`][lbutils.graphics.colours.Colour] to use when
+        drawing.
+    pen: graphics.Pen
+        The [`Pen`][lbutils.graphics.Pen] to use when drawing on the canvas.
+    height: int
+        A read-only value for the height of the canvas in pixels.
+    width: int
+        A read-only value for the width of the canvas in pixels.
     x: int
             The X co-ordinate value of the `cursor`
     y: int
@@ -200,7 +200,7 @@ class OLEDrgb(graphics.Canvas):
             A tuple representing the co-ordinate (x ,y) of the `cursor`
 
     Methods
-    ----------
+    -------
 
     **Cursor and Origin Movements**
 
@@ -382,20 +382,9 @@ class OLEDrgb(graphics.Canvas):
         Once a suitable object has been instantiated, the drawing methods
         provided by the rest of this class can be used.
 
-        Attributes
-        ----------
-
-        font: Type[BaseFont]
-            The current font in use for the display, which will be
-            an instance of
-            [`lbutils.graphics.fonts.BaseFont`][lbutils.graphics.fonts.base_font.BaseFont].
-            All subsequent text methods (e.g. `write_text`) will make use of
-            the specified `font` until this attribute is changed.
-
-
         Parameters
         ----------
-        spi_controller: Type[SPI]
+        spi_controller: SPI
             An instance of the
             [`machine.SPI`](https://docs.micropython.org/en/latest/library/machine.SPI.html)
             class, used to specify the SPI interface that should be used by this
@@ -408,8 +397,7 @@ class OLEDrgb(graphics.Canvas):
         reset_pin: int, optional
             Normally 'low': when held 'high', clears the current display buffer.
             Used to clear the display without having to rewrite each pixel.
-            Defaults
-                        to GPIO Pin 17.
+            Defaults to GPIO Pin 17.
         width: int, optional
             The width in pixels of the display. Defaults to 96.
         height: int, optional
@@ -614,9 +602,9 @@ class OLEDrgb(graphics.Canvas):
                     self.cursor.y,
                     end[0],
                     end[1],
-                    use_fg_colour.bR,
-                    use_fg_colour.bG,
-                    use_fg_colour.bB,
+                    use_fg_colour.red,
+                    use_fg_colour.green,
+                    use_fg_colour.blue,
                 )
             else:
                 data = ustruct.pack(
@@ -625,9 +613,9 @@ class OLEDrgb(graphics.Canvas):
                     start[1],
                     end[0],
                     end[1],
-                    use_fg_colour.bR,
-                    use_fg_colour.bG,
-                    use_fg_colour.bB,
+                    use_fg_colour.red,
+                    use_fg_colour.green,
+                    use_fg_colour.blue,
                 )
         except Exception:
             raise ValueError(
@@ -716,12 +704,12 @@ class OLEDrgb(graphics.Canvas):
                 self.cursor.y,
                 self.cursor.x + width - 1,
                 self.cursor.y + height - 1,
-                use_fg_colour.bR,
-                use_fg_colour.bG,
-                use_fg_colour.bB,
-                use_bg_colour.bR,
-                use_bg_colour.bG,
-                use_bg_colour.bB,
+                use_fg_colour.red,
+                use_fg_colour.green,
+                use_fg_colour.blue,
+                use_bg_colour.red,
+                use_bg_colour.green,
+                use_bg_colour.blue,
             )
         else:
             # Send the drawing command (the colour data is ignored if the
@@ -732,18 +720,18 @@ class OLEDrgb(graphics.Canvas):
                 start[1],
                 start[0] + width - 1,
                 start[1] + height - 1,
-                use_fg_colour.bR,
-                use_fg_colour.bG,
-                use_fg_colour.bB,
-                use_bg_colour.bR,
-                use_bg_colour.bG,
-                use_bg_colour.bB,
+                use_fg_colour.red,
+                use_fg_colour.green,
+                use_fg_colour.blue,
+                use_bg_colour.red,
+                use_bg_colour.green,
+                use_bg_colour.blue,
             )
 
         self._write(_DRAWRECT, data)
 
     def reset(self) -> None:
-        """Resets the display, clearing the current contents."""
+        """Reset the display, clearing the current contents."""
         if self.reset_pin is not None:
             self.reset_pin.value(0)
             utime.sleep(0.1)

--- a/lbutils/pmods/spi/oledrgb.py
+++ b/lbutils/pmods/spi/oledrgb.py
@@ -78,7 +78,7 @@ except ImportError:
 
 # Import the lbutils graphics library
 try:
-    import lbutils.graphics as graphics
+    from lbutils import graphics
 except ImportError:
     msg = ("Error: Missing required LBUtils graphics library",)
     raise RuntimeError(msg) from ImportError

--- a/lbutils/pmods/spi/oledrgb.py
+++ b/lbutils/pmods/spi/oledrgb.py
@@ -81,7 +81,7 @@ try:
     import lbutils.graphics as graphics
 except ImportError:
     raise RuntimeError(
-        "Error: Missing required LBUtils graphics library"
+        "Error: Missing required LBUtils graphics library",
     ) from ImportError
 
 # Import the core libraries
@@ -477,7 +477,12 @@ class OLEDrgb(graphics.Canvas):
             self.chip_sel_pin.value(1)
 
     def _block(
-        self, x: int, y: int, width: int, height: int, data: Union[bytes, bytearray]
+        self,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        data: Union[bytes, bytearray],
     ) -> None:
         self._write(_SETCOLUMN, bytearray([x, x + width - 1]))
         self._write(_SETROW, bytearray([y, y + height - 1]))
@@ -646,7 +651,7 @@ class OLEDrgb(graphics.Canvas):
             raise ValueError(
                 "Invalid parameters has been passed to 'draw_line'. I cannot"
                 "interpret the co-ordinates passed as arguments: check the"
-                "'start' and 'end' tuples are correct"
+                "'start' and 'end' tuples are correct",
             ) from ustruct.error
 
         self._write(_DRAWLINE, data)

--- a/lbutils/pmods/spi/oledrgb.py
+++ b/lbutils/pmods/spi/oledrgb.py
@@ -533,7 +533,7 @@ class OLEDrgb(graphics.Canvas):
         self._write(_SETROW, bytearray([y, y]))
 
         #          self._write(None,bytearray([colour >> 8, colour &0xff]))
-        self.draw_line(start=(x, y), end=(x, y))
+        self.draw_line(start=(x, y), end=(x, y), fg_colour=colour)
 
     def draw_line(
         self,

--- a/lbutils/pmods/spi/oledrgb.py
+++ b/lbutils/pmods/spi/oledrgb.py
@@ -368,7 +368,7 @@ class OLEDrgb(graphics.Canvas):
         reset_pin = Pin(17, Pin.OUT)
         ````
 
-        The display backlight, and the low-power mode of the display
+        The display back-light, and the low-power mode of the display
         driver, are controlled by a `vcc_enable` GPIO pin. In normal use
         this GPIO pin is set 'high': for low-power mode this pin should
         be set 'low'. During initialisation it is normal to set this pin
@@ -427,7 +427,7 @@ class OLEDrgb(graphics.Canvas):
         self.chip_sel_pin = chip_sel_pin
         self.reset_pin = reset_pin
 
-        # Initalise the diaplay
+        # Initialise the display
         self.reset()
         for command, data in self._INIT:
             self._write(command, data)

--- a/lbutils/pmods/spi/oledrgb.py
+++ b/lbutils/pmods/spi/oledrgb.py
@@ -80,9 +80,8 @@ except ImportError:
 try:
     import lbutils.graphics as graphics
 except ImportError:
-    raise RuntimeError(
-        "Error: Missing required LBUtils graphics library",
-    ) from ImportError
+    msg = ("Error: Missing required LBUtils graphics library",)
+    raise RuntimeError(msg) from ImportError
 
 # Import the core libraries
 import ustruct
@@ -648,11 +647,12 @@ class OLEDrgb(graphics.Canvas):
                     use_fg_colour.blue,
                 )
         except ustruct.error:
-            raise ValueError(
+            msg = (
                 "Invalid parameters has been passed to 'draw_line'. I cannot"
                 "interpret the co-ordinates passed as arguments: check the"
                 "'start' and 'end' tuples are correct",
-            ) from ustruct.error
+            )
+            raise ValueError(msg) from ustruct.error
 
         self._write(_DRAWLINE, data)
 

--- a/lbutils/typing.py
+++ b/lbutils/typing.py
@@ -210,12 +210,13 @@ def _overload_dummy(*args, **kwds):
     NotImplementedError:
         This is a stub and cannot be called directly,
     """
-    raise NotImplementedError(
+    msg = (
         "You should not call an overloaded function. "
         "A series of @overload-decorated functions "
         "outside a stub module should always be followed "
-        "by an implementation that is not @overload-ed.",
+        "by an implementation that is not @overload-ed."
     )
+    raise NotImplementedError(msg)
 
 
 def overload(fun):

--- a/lbutils/typing.py
+++ b/lbutils/typing.py
@@ -214,7 +214,7 @@ def _overload_dummy(*args, **kwds):
         "You should not call an overloaded function. "
         "A series of @overload-decorated functions "
         "outside a stub module should always be followed "
-        "by an implementation that is not @overload-ed."
+        "by an implementation that is not @overload-ed.",
     )
 
 

--- a/lbutils/typing.py
+++ b/lbutils/typing.py
@@ -194,7 +194,7 @@ def cast(typ, val):
 
 
 def _overload_dummy(*args, **kwds):
-    """Helper for @overload to raise when called.
+    """Raise `NotImplementedError` for @overload when called.
 
     Parameters
     ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = ["lbutils", "lbutils.drivers", "lbutils.graphics", "lbutils.graphics.
 
 [tool.ruff]
 # Enable modules for static type and doc checking
-select = ["A", "ANN0", "ANN2", "B", "BLE", "COM", "D4", "E", "F", "FBT", "I", "N", "Q",  "S", "UP", "W"]
+select = ["A", "ANN0", "ANN2", "B", "BLE", "C4", "COM", "D4", "DTZ", "E", "EM", "F", "FBT", "I", "N", "Q",  "S", "UP", "W"]
 
 # Ignore
 # * F401 - Handle redundant imports via the module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,14 +33,15 @@ packages = ["lbutils", "lbutils.drivers", "lbutils.graphics", "lbutils.graphics.
 
 [tool.ruff]
 # Enable modules for static type and doc checking
-select = ["A", "ANN0", "ANN2", "B", "BLE", "C4", "COM", "D4", "DTZ", "E", "EM", "F", "FBT", "I", "ICN", "INP", "ISC", "N", "Q",  "S", "UP", "W"]
+select = ["A", "ANN0", "ANN2", "B", "BLE", "C4", "COM", "D4", "DTZ", "E", "EM", "F", "FBT", "I", "ICN", "INP", "ISC", "N", "PIE", "Q",  "S", "UP", "W"]
 
 # Ignore
 # * F401 - Handle redundant imports via the module.
 # * F821 - ypes needed by the static type checker
 # * D412,D416 - Document formatting handled by docformatter
 # * N802 - Ignore special cases of mixedCase variables in the typing libraray
-ignore = ["D412", "D416", "F401", "F821", "N802"]
+# * PIE790 - Ignore pass comments as these are required to stop black fighting docformatter
+ignore = ["D412", "D416", "F401", "F821", "N802", "PIE790"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = ["lbutils", "lbutils.drivers", "lbutils.graphics", "lbutils.graphics.
 
 [tool.ruff]
 # Enable modules for static type and doc checking
-select = ["A", "ANN0", "ANN2", "B", "BLE", "C4", "COM", "D4", "DTZ", "E", "EM", "F", "FBT", "I", "N", "Q",  "S", "UP", "W"]
+select = ["A", "ANN0", "ANN2", "B", "BLE", "C4", "COM", "D4", "DTZ", "E", "EM", "F", "FBT", "I", "ICN", "INP", "ISC", "N", "Q",  "S", "UP", "W"]
 
 # Ignore
 # * F401 - Handle redundant imports via the module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = ["lbutils", "lbutils.drivers", "lbutils.graphics", "lbutils.graphics.
 
 [tool.ruff]
 # Enable modules for static type and doc checking
-select = ["ANN0", "ANN2", "B", "BLE", "D4", "E", "F", "FBT", "I", "N", "Q",  "S", "UP", "W"]
+select = ["A", "ANN0", "ANN2", "B", "BLE", "COM", "D4", "E", "F", "FBT", "I", "N", "Q",  "S", "UP", "W"]
 
 # Ignore
 # * F401 - Handle redundant imports via the module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = ["lbutils", "lbutils.drivers", "lbutils.graphics", "lbutils.graphics.
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F", "Q", "FBT"]
+select = ["E", "F", "FBT", "I", "Q",  "W"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = ["lbutils", "lbutils.drivers", "lbutils.graphics", "lbutils.graphics.
 
 [tool.ruff]
 # Enable modules for static type and doc checking
-select = ["ANN0", "ANN2", "D4", "E", "F", "FBT", "I", "N", "Q",  "UP", "W"]
+select = ["ANN0", "ANN2", "BLE", "D4", "E", "F", "FBT", "I", "N", "Q",  "S", "UP", "W"]
 
 # Ignore
 # * F401 - Handle redundant imports via the module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = ["lbutils", "lbutils.drivers", "lbutils.graphics", "lbutils.graphics.
 
 [tool.ruff]
 # Enable modules for static type and doc checking
-select = ["ANN0", "ANN2", "BLE", "D4", "E", "F", "FBT", "I", "N", "Q",  "S", "UP", "W"]
+select = ["ANN0", "ANN2", "B", "BLE", "D4", "E", "F", "FBT", "I", "N", "Q",  "S", "UP", "W"]
 
 # Ignore
 # * F401 - Handle redundant imports via the module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = ["lbutils", "lbutils.drivers", "lbutils.graphics", "lbutils.graphics.
 
 [tool.ruff]
 # Enable modules for static type and doc checking
-select = ["A", "ANN0", "ANN2", "B", "BLE", "C4", "COM", "D4", "DTZ", "E", "EM", "F", "FBT", "I", "ICN", "INP", "ISC", "N", "PIE", "Q",  "S", "UP", "W"]
+select = ["A", "ANN0", "ANN2", "ARG", "B", "BLE", "C4", "COM", "D4", "DTZ", "E", "EM", "F", "FBT", "I", "ICN", "INP", "INT", "ISC", "N", "PIE", "PT", "PYI", "Q",  "RSE", "S", "SIM", "SLF", "TID", "TCH", "UP", "W"]
 
 # Ignore
 # * F401 - Handle redundant imports via the module.
@@ -75,7 +75,7 @@ target-version = "py310"
 
 [tool.ruff.per-file-ignores]
 # Ignore 'typing' as far as possible
-"lbutils/typing.py" = ["ANN"]
+"lbutils/typing.py" = ["ANN", "ARG"]
 
 [tool.ruff.mccabe]
 # Unlike Flake8, default to a complexity level of 10.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = ["lbutils", "lbutils.drivers", "lbutils.graphics", "lbutils.graphics.
 
 [tool.ruff]
 # Enable modules for static type and doc checking
-select = ["A", "ANN0", "ANN2", "ARG", "B", "BLE", "C4", "COM", "D4", "DTZ", "E", "EM", "F", "FBT", "I", "ICN", "INP", "INT", "ISC", "N", "PIE", "PL", "PT", "PYI", "Q",  "RSE", "S", "SIM", "SLF", "TID", "TCH", "UP", "W"]
+select = ["A", "ANN0", "ANN2", "ARG", "B", "BLE", "C4", "COM", "D4", "DTZ", "E", "EM", "F", "FBT", "I", "ICN", "INP", "INT", "ISC", "N", "PIE", "PL", "PLC", "PLE", "PLR", "PLW", "PT", "PYI", "Q",  "RSE", "RUF", "S", "SIM", "SLF", "TID", "TCH", "TRY", "UP", "W"]
 
 # Ignore
 # * F401 - Handle redundant imports via the module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,14 @@ packages = ["lbutils", "lbutils.drivers", "lbutils.graphics", "lbutils.graphics.
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F", "FBT", "I", "Q",  "W"]
+select = ["D4", "E", "F", "FBT", "I", "N", "Q",  "UP", "W"]
+
+# Ignore
+# * F401 - Handle redundant imports via the module.
+# * F821 - ypes needed by the static type checker
+# * D412,D416 - Document formatting handled by docformatter
+# * N802 - Ignore special cases of mixedCase variables in the typing libraray
+ignore = ["D412", "D416", "F401", "F821", "N802"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
@@ -61,10 +68,6 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 # Handle modules slightly differently
 ignore-init-module-imports = true
-
-# Handle redundant imports via the module. Ignore types needed by the type
-# linter
-ignore = ["F401", "F821"]
 
 # Assume Python 3.10.
 target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ black = true
 packages = ["lbutils", "lbutils.drivers", "lbutils.graphics", "lbutils.graphics.fonts", "lbutils.helpers", "lbutils.pmods", "lbutils.pmods.spi", "lbutils.pmods.i2c"]
 
 [tool.ruff]
-# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["D4", "E", "F", "FBT", "I", "N", "Q",  "UP", "W"]
+# Enable modules for static type and doc checking
+select = ["ANN0", "ANN2", "D4", "E", "F", "FBT", "I", "N", "Q",  "UP", "W"]
 
 # Ignore
 # * F401 - Handle redundant imports via the module.
@@ -71,6 +71,10 @@ ignore-init-module-imports = true
 
 # Assume Python 3.10.
 target-version = "py310"
+
+[tool.ruff.per-file-ignores]
+# Ignore 'typing' as far as possible
+"lbutils/typing.py" = ["ANN"]
 
 [tool.ruff.mccabe]
 # Unlike Flake8, default to a complexity level of 10.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = ["lbutils", "lbutils.drivers", "lbutils.graphics", "lbutils.graphics.
 
 [tool.ruff]
 # Enable modules for static type and doc checking
-select = ["A", "ANN0", "ANN2", "ARG", "B", "BLE", "C4", "COM", "D4", "DTZ", "E", "EM", "F", "FBT", "I", "ICN", "INP", "INT", "ISC", "N", "PIE", "PT", "PYI", "Q",  "RSE", "S", "SIM", "SLF", "TID", "TCH", "UP", "W"]
+select = ["A", "ANN0", "ANN2", "ARG", "B", "BLE", "C4", "COM", "D4", "DTZ", "E", "EM", "F", "FBT", "I", "ICN", "INP", "INT", "ISC", "N", "PIE", "PL", "PT", "PYI", "Q",  "RSE", "S", "SIM", "SLF", "TID", "TCH", "UP", "W"]
 
 # Ignore
 # * F401 - Handle redundant imports via the module.
@@ -41,7 +41,9 @@ select = ["A", "ANN0", "ANN2", "ARG", "B", "BLE", "C4", "COM", "D4", "DTZ", "E",
 # * D412,D416 - Document formatting handled by docformatter
 # * N802 - Ignore special cases of mixedCase variables in the typing libraray
 # * PIE790 - Ignore pass comments as these are required to stop black fighting docformatter
-ignore = ["D412", "D416", "F401", "F821", "N802", "PIE790"]
+# * PLR0913 - We use optional arguments a lot, so ignore complaints about the number of arguments
+# * PLR0912 - Ignore deep branches
+ignore = ["D412", "D416", "F401", "F821", "N802", "PIE790", "PLR0912", "PLR0913"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]


### PR DESCRIPTION
Add checks to ruff for typing, syntax and documentation linting. This should help mypy to pick-up type errors, and ensure the overall consistency of the documentation. To help, the ruff checks have also been added as a GitHub action.